### PR TITLE
Improved Landscape loading performance

### DIFF
--- a/JortPob/ESM/Landscape.cs
+++ b/JortPob/ESM/Landscape.cs
@@ -17,6 +17,7 @@ namespace JortPob
         public readonly string flags;
 
         public readonly List<Vertex> vertices;
+        public readonly Dictionary<Vertex, int> vertices_indices;
         public readonly List<int>[] indices;   // 0 is full detail, 1 is reduced detail for lod, 2 is minimum possible detail for super overworld
         public readonly Vertex[,] borders;
 
@@ -107,6 +108,7 @@ namespace JortPob
             /* Vertex Data */
             Vector3 centerOffset = new Vector3((Const.CELL_SIZE / 2f), 0f, -(Const.CELL_SIZE / 2f));
             vertices = new();
+            vertices_indices = new();
             Vertex[,] vertgrid = new Vertex[Const.CELL_GRID_SIZE+1, Const.CELL_GRID_SIZE+1];
             float last = offset;
             float lastEdge = last;
@@ -135,6 +137,7 @@ namespace JortPob
                     }
 
                     Vertex vertex = new Vertex(position, grid, Vector3.Normalize(new Vector3(iii, kkk, jjj)), new Vector2(xx * (1f / Const.CELL_GRID_SIZE), yy * (1f / Const.CELL_GRID_SIZE)), color, ltex[Math.Min((xx) / 4, 15), Math.Min((Const.CELL_GRID_SIZE - yy) / 4, 15)]);
+                    vertices_indices.Add(vertex, vertices.Count);
                     vertices.Add(vertex);
                     vertgrid[xx, yy] = vertex;
                 }
@@ -291,17 +294,6 @@ namespace JortPob
                     }
                 }
 
-                int GetSkirtIndex(Vertex vert)
-                {
-                    for (int i = 0; i < vertices.Count(); i++)
-                    {
-                        Vertex v = vertices[i];
-                        if (v == vert) { return i; }
-                    }
-                    return -1; // instant death, should not happen
-                }
-
-
                 // Y0 border
                 Vertex vlast = null;
                 for (int xx = 0; xx <= Const.CELL_GRID_SIZE; xx += lod.DIVISOR)
@@ -315,16 +307,16 @@ namespace JortPob
                     {
                         Vertex v1 = vertgrid[f, 0];
                         Vertex v2 = vertgrid[f + 1, 0];
-                        indices[lod.INDEX].Add(GetSkirtIndex(vroot));
-                        indices[lod.INDEX].Add(GetSkirtIndex(v2));
-                        indices[lod.INDEX].Add(GetSkirtIndex(v1));
+                        indices[lod.INDEX].Add(vertices_indices[vroot]);
+                        indices[lod.INDEX].Add(vertices_indices[v2]);
+                        indices[lod.INDEX].Add(vertices_indices[v1]);
                     }
                     if (vlast != null && vlast != vroot)
                     {
                         Vertex v = vertgrid[start, 0];
-                        indices[lod.INDEX].Add(GetSkirtIndex(vroot));
-                        indices[lod.INDEX].Add(GetSkirtIndex(v));
-                        indices[lod.INDEX].Add(GetSkirtIndex(vlast));
+                        indices[lod.INDEX].Add(vertices_indices[vroot]);
+                        indices[lod.INDEX].Add(vertices_indices[v]);
+                        indices[lod.INDEX].Add(vertices_indices[vlast]);
                     }
                     vlast = vroot;
                 }
@@ -343,16 +335,16 @@ namespace JortPob
                     {
                         Vertex v1 = vertgrid[f, Yp];
                         Vertex v2 = vertgrid[f + 1, Yp];
-                        indices[lod.INDEX].Add(GetSkirtIndex(vroot));
-                        indices[lod.INDEX].Add(GetSkirtIndex(v1));
-                        indices[lod.INDEX].Add(GetSkirtIndex(v2));
+                        indices[lod.INDEX].Add(vertices_indices[vroot]);
+                        indices[lod.INDEX].Add(vertices_indices[v1]);
+                        indices[lod.INDEX].Add(vertices_indices[v2]);
                     }
                     if (vlast != null && vlast != vroot)
                     {
                         Vertex v = vertgrid[start, Yp];
-                        indices[lod.INDEX].Add(GetSkirtIndex(vroot));
-                        indices[lod.INDEX].Add(GetSkirtIndex(vlast));
-                        indices[lod.INDEX].Add(GetSkirtIndex(v));
+                        indices[lod.INDEX].Add(vertices_indices[vroot]);
+                        indices[lod.INDEX].Add(vertices_indices[vlast]);
+                        indices[lod.INDEX].Add(vertices_indices[v]);
                     }
                     vlast = vroot;
                 }
@@ -370,16 +362,16 @@ namespace JortPob
                         {
                             Vertex v1 = vertgrid[0, f];
                             Vertex v2 = vertgrid[0, f + 1];
-                            indices[lod.INDEX].Add(GetSkirtIndex(vroot));
-                            indices[lod.INDEX].Add(GetSkirtIndex(v1));
-                            indices[lod.INDEX].Add(GetSkirtIndex(v2));
+                            indices[lod.INDEX].Add(vertices_indices[vroot]);
+                            indices[lod.INDEX].Add(vertices_indices[v1]);
+                            indices[lod.INDEX].Add(vertices_indices[v2]);
                         }
                         if (vlast != null && vlast != vroot)
                         {
                             Vertex v = vertgrid[0, start];
-                            indices[lod.INDEX].Add(GetSkirtIndex(vroot));
-                            indices[lod.INDEX].Add(GetSkirtIndex(vlast));
-                            indices[lod.INDEX].Add(GetSkirtIndex(v));
+                            indices[lod.INDEX].Add(vertices_indices[vroot]);
+                            indices[lod.INDEX].Add(vertices_indices[vlast]);
+                            indices[lod.INDEX].Add(vertices_indices[v]);
                         }
                         vlast = vroot;
                 }
@@ -398,16 +390,16 @@ namespace JortPob
                     {
                         Vertex v1 = vertgrid[Xp, f];
                         Vertex v2 = vertgrid[Xp, f + 1];
-                        indices[lod.INDEX].Add(GetSkirtIndex(vroot));
-                        indices[lod.INDEX].Add(GetSkirtIndex(v2));
-                        indices[lod.INDEX].Add(GetSkirtIndex(v1));
+                        indices[lod.INDEX].Add(vertices_indices[vroot]);
+                        indices[lod.INDEX].Add(vertices_indices[v2]);
+                        indices[lod.INDEX].Add(vertices_indices[v1]);
                     }
                     if (vlast != null && vlast != vroot)
                     {
                         Vertex v = vertgrid[Xp, start];
-                        indices[lod.INDEX].Add(GetSkirtIndex(vroot));
-                        indices[lod.INDEX].Add(GetSkirtIndex(v));
-                        indices[lod.INDEX].Add(GetSkirtIndex(vlast));
+                        indices[lod.INDEX].Add(vertices_indices[vroot]);
+                        indices[lod.INDEX].Add(vertices_indices[v]);
+                        indices[lod.INDEX].Add(vertices_indices[vlast]);
                     }
                     vlast = vroot;
                 }
@@ -504,19 +496,6 @@ namespace JortPob
                 GetMesh(texset);
             }
 
-            /* Now that we've made the meshes we need fill out those indices */
-            int GetIndex(Mesh mesh, Vertex vert)
-            {
-                for (int i = 0;i<mesh.vertices.Count();i++)
-                {
-                    Vertex v = mesh.vertices[i];
-                    if (v == vert) { return i; }
-                }
-
-                mesh.vertices.Add(vert);
-                return mesh.vertices.Count() - 1;
-            }
-
             foreach (Const.LOD_VALUE lod in Const.TERRAIN_LOD_VALUES)
             {
                 for (int itr = 0; itr < indices[lod.INDEX].Count; itr += 3)
@@ -536,9 +515,9 @@ namespace JortPob
 
                     Mesh mesh = GetMesh(texs);
 
-                    int A = GetIndex(mesh, a);
-                    int B = GetIndex(mesh, b);
-                    int C = GetIndex(mesh, c);
+                    int A = mesh.AddVertex(a);
+                    int B = mesh.AddVertex(b);
+                    int C = mesh.AddVertex(c);
 
                     mesh.indices[lod.INDEX].Add(A);
                     mesh.indices[lod.INDEX].Add(B);
@@ -575,6 +554,7 @@ namespace JortPob
             public readonly List<Texture> textures;
             public readonly List<int>[] indices;    
             public readonly List<Vertex> vertices;
+            public readonly Dictionary<Vertex, int> vertices_indices;
 
             public readonly MaterialContext.MaterialTemplate template;
 
@@ -583,7 +563,18 @@ namespace JortPob
                 this.textures = textures;
                 indices = new List<int>[] { new(), new(), new() };  // 0 is full detail, 1 is reduced detail for lod, 2 is minimum possible detail for super overworld
                 vertices = new();
+                vertices_indices = new();
                 this.template = template;
+            }
+
+            public int AddVertex(Vertex vertex)
+            {
+                if (vertices_indices.TryGetValue(vertex, out int existing_index))
+                    return existing_index;
+                var index = vertices.Count;
+                vertices_indices.Add(vertex, vertices.Count);
+                vertices.Add(vertex);
+                return index;
             }
         }
 

--- a/JortPob/LiquidManager.cs
+++ b/JortPob/LiquidManager.cs
@@ -653,6 +653,10 @@ namespace JortPob
         /* Returns true if added, false if not added */
         public static List<Cutout> CUTOUTS = new();
         public static List<ShapedCutout> SHAPED_CUTOUTS = new(); // literally like 2 things. we almost got away with just using squares but bethesda really just HAD to fuck it up
+
+        private static readonly Dictionary<Cutout.Type, List<Cutout>> CUTOUTS_BY_TYPE = new();
+        private static readonly Dictionary<Cutout.Type, List<Cutout>> SHAPED_CUTOUTS_BY_TYPE = new();
+
         public static bool AddCutout(Content content)
         {
             float s;
@@ -674,31 +678,52 @@ namespace JortPob
             {
                 ShapedCutout cutout = new(type, content.position - offsetJank, content.rotation, content.mesh);
                 SHAPED_CUTOUTS.Add(cutout);
+
+                if (SHAPED_CUTOUTS_BY_TYPE.TryGetValue(type, out List<Cutout> value))
+                    value.Add(cutout);
+                else
+                    SHAPED_CUTOUTS_BY_TYPE.Add(type, [cutout]);
+
                 return true;
             }
             else
             {
                 Cutout cutout = new(type, content.position - offsetJank, content.rotation, s);
                 CUTOUTS.Add(cutout);
+
+                if (CUTOUTS_BY_TYPE.TryGetValue(type, out List<Cutout> value))
+                    value.Add(cutout);
+                else
+                    CUTOUTS_BY_TYPE.Add(type, [cutout]);
+
                 return true;
             }
         }
 
         public static bool PointInCutout(Cutout.Type type, Vector3 position, bool includeShapedCutouts = false)
         {
-            foreach(Cutout cutout in CUTOUTS)
+            var positionY = position.Y;
+
+            // Check regular cutouts of this type only
+            if (CUTOUTS_BY_TYPE.TryGetValue(type, out var regularCutouts))
             {
-                if(cutout.type != type) { continue; }
-                if (cutout.IsInside(position, false) && position.Y <= cutout.height) { return true; }
-            }
-            if (includeShapedCutouts)
-            {
-                foreach (Cutout cutout in SHAPED_CUTOUTS)
+                foreach (var cutout in regularCutouts)
                 {
-                    if (cutout.type != type) { continue; }
-                    if (cutout.IsInside(position, false) && position.Y <= cutout.height) { return true; }
+                    if (positionY <= cutout.height && cutout.IsInside(position, false))
+                        return true;
                 }
             }
+
+            // Check shaped cutouts of this type only
+            if (includeShapedCutouts && SHAPED_CUTOUTS_BY_TYPE.TryGetValue(type, out var shapedCutouts))
+            {
+                foreach (var cutout in shapedCutouts)
+                {
+                    if (positionY <= cutout.height && cutout.IsInside(position, false))
+                        return true;
+                }
+            }
+
             return false;
         }
 
@@ -2139,6 +2164,7 @@ namespace JortPob
             public readonly Vector3 position, rotation;
             public float size;
             public float height;
+
             public Cutout(Type type, Vector3 position, Vector3 rotation, float size)
             {
                 this.type = type;
@@ -2218,6 +2244,9 @@ namespace JortPob
             // Convex shape test, code adapted from a triangle sameside point inside example
             public bool IsInside(Vector3 v, bool edgeInclusive)
             {
+                if (Vector3.DistanceSquared(v, position) > size * size)
+                    return false;
+
                 if (edgeInclusive)
                 {
                     foreach (Vector3 p in Points())
@@ -2237,10 +2266,10 @@ namespace JortPob
 
                 // Iterate through all our edges and make sure the point always falls on the same side of an edge as the next edge endpoint
                 List<WetEdge> edges = Edges();
-                for(int i=0;i<edges.Count();i++)
+                for (int i = 0; i < edges.Count; i++)
                 {
                     WetEdge edge = edges[i];
-                    WetEdge next = edges[(i+1) % edges.Count];
+                    WetEdge next = edges[(i + 1) % edges.Count];
                     if (!SameSide(v, next.b, edge)) { return false; }
                 }
 


### PR DESCRIPTION
This brings the average processing time of a Landscape from 1.5-2.0 seconds to 28-35 milliseconds (on my PC).

- Turned 2 quadratic operations into linear ones by using vertex index lookups.
- Added an early exit in Cutout.IsInside using a circumscribed circle bounds check.
- Created a typed lookup for CUTOUTS and SHAPED_CUTOUTS

I feel like removing the dictionaries for the CUTOUTS and SHAPED_CUTOUTS because it only save 10ms and it's kind of ugly in my opinion.