### PR TITLE
Improved Landscape conversion performance

### DIFF
--- a/JortPob/Common/Obj.cs
+++ b/JortPob/Common/Obj.cs
@@ -92,43 +92,42 @@ namespace JortPob.Common
         public Obj optimize() {
             Obj nu = new();
 
+            Dictionary<Vector3, int> vsLookup = new();
+            Dictionary<Vector3, int> vnsLookup = new();
+            Dictionary<Vector3, int> vtsLookup = new();
+
             int[] GetIndex(Vector3 v, Vector3 vn, Vector3 vt)
             {
-                int[] indset = new int[] { -1, -1, -1 };
+                int[] indset = new int[3];
+
                 // V
-                for(int i=0;i<nu.vs.Count();i++)
+                if (!vsLookup.TryGetValue(v, out indset[0]))
                 {
-                    if (nu.vs[i] == v) { indset[0] = i; break; }
-                }
-                if (indset[0] == -1) {
+                    indset[0] = nu.vs.Count;
                     nu.vs.Add(v);
-                    indset[0] = nu.vs.Count() - 1;
+                    vsLookup[v] = indset[0];
                 }
-                //VN
-                for (int i = 0; i < nu.vns.Count(); i++)
+
+                // VN  
+                if (!vnsLookup.TryGetValue(vn, out indset[1]))
                 {
-                    if (nu.vns[i] == vn) { indset[1] = i; break; }
-                }
-                if (indset[1] == -1)
-                {
+                    indset[1] = nu.vns.Count;
                     nu.vns.Add(vn);
-                    indset[1] = nu.vns.Count() - 1;
+                    vnsLookup[vn] = indset[1];
                 }
-                //VT
-                for (int i = 0; i < nu.vts.Count(); i++)
+
+                // VT
+                if (!vtsLookup.TryGetValue(vt, out indset[2]))
                 {
-                    if (nu.vts[i] == vt) { indset[2] = i; break; }
-                }
-                if (indset[2] == -1)
-                {
+                    indset[2] = nu.vts.Count;
                     nu.vts.Add(vt);
-                    indset[2] = nu.vts.Count() - 1;
+                    vtsLookup[vt] = indset[2];
                 }
 
                 return indset;
             }
 
-            foreach(ObjG g in gs)
+            foreach (ObjG g in gs)
             {
                 ObjG nug = new();
                 nug.name = g.name;

--- a/JortPob/Model/FLVERUtil.cs
+++ b/JortPob/Model/FLVERUtil.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 
 namespace JortPob.Model
 {
@@ -34,79 +35,68 @@ namespace JortPob.Model
         public static FLVER2 Optimize(FLVER2 flver)
         {
             /* Delete unused materials */
-            for(int i=0;i<flver.Materials.Count();i++)
+            HashSet<int> usedMaterials = new();
+            foreach (FLVER2.Mesh mesh in flver.Meshes)
             {
-                // Check if unused
-                FLVER2.Material material = flver.Materials[i];
-                bool unused = true;
-                foreach(FLVER2.Mesh mesh in flver.Meshes)
-                {
-                    if (mesh.MaterialIndex == material.Index) { unused = false; break; }
-                }
-                // Delete and resolve indices
-                if (unused)
+                usedMaterials.Add(mesh.MaterialIndex);
+            }
+            for (int i = flver.Materials.Count - 1; i >= 0; i--)
+            {
+                if (!usedMaterials.Contains(i))
                 {
                     flver.Materials.RemoveAt(i);
-                    foreach(FLVER2.Material mat in flver.Materials)
+                    foreach (FLVER2.Material mat in flver.Materials)
                     {
-                        if(mat.Index > i) { mat.Index--; }
+                        if (mat.Index > i) { mat.Index--; }
                     }
-                    foreach(FLVER2.Mesh mesh in flver.Meshes)
+                    foreach (FLVER2.Mesh mesh in flver.Meshes)
                     {
-                        if(mesh.MaterialIndex > i) { mesh.MaterialIndex--; }
+                        if (mesh.MaterialIndex > i) { mesh.MaterialIndex--; }
                     }
-                    i--;
                 }
             }
 
             /* Delete unused bufferlayouts */
-            for (int i = 0; i < flver.BufferLayouts.Count(); i++)
+            HashSet<int> usedLayouts = new();
+            foreach (FLVER2.Mesh mesh in flver.Meshes)
             {
-                // Check if unused
-                FLVER2.BufferLayout layout = flver.BufferLayouts[i];
-                bool unused = true;
-                foreach (FLVER2.Mesh mesh in flver.Meshes)
+                foreach (FLVER2.VertexBuffer buffer in mesh.VertexBuffers)
                 {
-                    foreach(FLVER2.VertexBuffer buffer in mesh.VertexBuffers)
-                    {
-                        if(buffer.LayoutIndex == i) { unused = false; break; }
-                    }
-                    if(!unused) { break; }
+                    usedLayouts.Add(buffer.LayoutIndex);
                 }
-                // Delete and resolve indices
-                if (unused)
+            }
+
+            for (int i = flver.BufferLayouts.Count - 1; i >= 0; i--)
+            {
+                if (!usedLayouts.Contains(i))
                 {
                     flver.BufferLayouts.RemoveAt(i);
                     foreach (FLVER2.Mesh mesh in flver.Meshes)
                     {
-                        foreach(FLVER2.VertexBuffer vb in mesh.VertexBuffers)
+                        foreach (FLVER2.VertexBuffer vb in mesh.VertexBuffers)
                         {
                             if (vb.LayoutIndex > i) { vb.LayoutIndex--; }
                         }
                     }
-                    i--;
                 }
             }
 
+
             /* Delete unused gxlists */
-            for (int i = 0; i < flver.GXLists.Count(); i++)
+            HashSet<int> usedGXLists = new();
+            foreach (FLVER2.Material mat in flver.Materials)
             {
-                // Check if unused
-                FLVER2.GXList gxlist = flver.GXLists[i];
-                bool unused = true;
-                foreach (FLVER2.Material mat in flver.Materials)
-                {
-                    if (mat.GXIndex == i) { unused = false; break; }
-                }
-                // Delete and resolve indices
-                if (unused)
+                usedGXLists.Add(mat.GXIndex);
+            }
+            for (int i = flver.GXLists.Count - 1; i >= 0; i--)
+            {
+                if (!usedGXLists.Contains(i))
                 {
                     flver.GXLists.RemoveAt(i);
                     foreach (FLVER2.Material mat in flver.Materials)
                     {
-                        if(mat.GXIndex > i) { mat.GXIndex--; }
+                        if (mat.GXIndex > i) { mat.GXIndex--; }
                     }
-                    i--;
                 }
             }
 
@@ -116,26 +106,21 @@ namespace JortPob.Model
                 List<FLVER.Vertex> verts = mesh.Vertices; // original vertices
                 mesh.Vertices = new();
 
+                Dictionary<VertexKey, int> vertexLookup = new();
+
                 int GetIndex(FLVER.Vertex v)
                 {
-                    for(int i=0;i<mesh.Vertices.Count();i++)
+                    VertexKey key = new VertexKey(v);
+
+                    if (vertexLookup.TryGetValue(key, out int existingIndex))
                     {
-                        FLVER.Vertex vert = mesh.Vertices[i];
-                        // check if vertex is a match
-                        if
-                        (
-                            vert.Position == v.Position &&   // @TODO: probably not good enough tbh, should look into rounding and comparison of values directly
-                            vert.Normal == v.Normal &&
-                            vert.UVs[0] == v.UVs[0] &&
-                            (vert.UVs.Count() > 1 ? vert.UVs[1] == v.UVs[1] : true)
-                        )
-                        {
-                            return i;
-                        }
+                        return existingIndex;
                     }
 
+                    int newIndex = mesh.Vertices.Count;
                     mesh.Vertices.Add(v);
-                    return mesh.Vertices.Count - 1;
+                    vertexLookup[key] = newIndex;
+                    return newIndex;
                 }
 
                 foreach (FLVER2.FaceSet faceSet in mesh.FaceSets)
@@ -154,6 +139,44 @@ namespace JortPob.Model
             }
 
             return flver;
+        }
+
+        private struct VertexKey : IEquatable<VertexKey>
+        {
+            private readonly Vector3 position;
+            private readonly Vector3 normal;
+            private readonly Vector3 uv0;
+            private readonly Vector3? uv1;
+            private readonly int hashCode;
+
+            public VertexKey(FLVER.Vertex vertex)
+            {
+                position = vertex.Position;
+                normal = vertex.Normal;
+                uv0 = vertex.UVs[0];
+                uv1 = vertex.UVs.Count > 1 ? vertex.UVs[1] : null;
+
+                hashCode = HashCode.Combine(position, normal, uv0, uv1);
+            }
+
+            public bool Equals(VertexKey other)
+            {
+                // @TODO: probably not good enough tbh, should look into rounding and comparison of values directly
+                return position == other.position &&
+                       normal == other.normal &&
+                       uv0 == other.uv0 &&
+                       uv1 == other.uv1;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is VertexKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                return hashCode;
+            }
         }
     }
 }


### PR DESCRIPTION
This brought my total Landscape conversion time down from 2 minutes to 25 seconds.

Same trick as before, replace linear lookups with dictionary lookups.
Also cleaned up some of the deletion code.
Pro tip: When deleting while iterating, do it in reverse so you don't have to fudge the index.