### PR TITLE
fix(JortPob): initialize vertexkey uvs before usage

### DIFF
--- a/JortPob/Model/FLVERUtil.cs
+++ b/JortPob/Model/FLVERUtil.cs
@@ -151,8 +151,10 @@ namespace JortPob.Model
 
             public VertexKey(FLVER.Vertex vertex)
             {
+                uvs = [];
                 position = vertex.Position;
                 normal = vertex.Normal;
+    
                 foreach(Vector3 uv in  vertex.UVs)
                 {
                     uvs.Add(uv);


### PR DESCRIPTION
This PR updates the `uvs` property of the `VertexKey` struct so that it is initialized before usage.