### PR TITLE
feat(JortPob/ESM): use lookups where possible for esm/landscape

### DIFF
--- a/JortPob/Cache.cs
+++ b/JortPob/Cache.cs
@@ -267,7 +267,7 @@ namespace JortPob
                 GC.Collect();
 
                 /* Create emitterinfos */
-                foreach(JsonNode json in esm.records[ESM.Type.Light])
+                foreach(JsonNode json in esm.GetAllRecordsByType(ESM.Type.Light))
                 {
                     if (json["mesh"] == null || json["mesh"].ToString().Trim() == "") { continue; }
 

--- a/JortPob/ESM/Landscape.cs
+++ b/JortPob/ESM/Landscape.cs
@@ -65,17 +65,9 @@ namespace JortPob
 
             textures = new();
             textures.Add(new Texture("Default Terrain Texture", $"{Const.MORROWIND_PATH}{Const.TERRAIN_DEFAULT_TEXTURE}", 65535));   // Default hardcoded terrain texture. Morrowind moment.
-            JsonNode GetLandscapeTextureRecord(int id)
-            {
-                foreach (JsonNode j in esm.records[ESM.Type.LandscapeTexture])
-                {
-                    if (int.Parse(j["index"].ToString()) == id)
-                    {
-                        return j;
-                    }
-                }
-                return null;
-            }
+
+            var landscapeTexturesByIndex = esm.GetAllRecordsByType(ESM.Type.LandscapeTexture)
+                .ToLookup(j => int.Parse(j["index"].ToString()));
 
             bool HasTexture(ushort id)
             {
@@ -90,7 +82,7 @@ namespace JortPob
             {
                 if (HasTexture(id)) { continue; }
 
-                JsonNode ltjson = GetLandscapeTextureRecord(id);
+                JsonNode ltjson = landscapeTexturesByIndex[id].FirstOrDefault();
 
                 if (ltjson != null)
                 {

--- a/JortPob/ESM/Landscape.cs
+++ b/JortPob/ESM/Landscape.cs
@@ -12,6 +12,8 @@ namespace JortPob
 {
     public class Landscape
     {
+        private static readonly ushort DEFAULT_TEXTURE_INDEX = 65535;
+
         public readonly Int2 coordinate;
 
         public readonly string flags;
@@ -21,7 +23,7 @@ namespace JortPob
         public readonly List<int>[] indices;   // 0 is full detail, 1 is reduced detail for lod, 2 is minimum possible detail for super overworld
         public readonly Vertex[,] borders;
 
-        public List<Texture> textures;
+        private readonly Dictionary<ushort, Texture> texturesByIndex;
 
         public List<Mesh> meshes;
 
@@ -63,34 +65,33 @@ namespace JortPob
                 }
             }
 
-            textures = new();
-            textures.Add(new Texture("Default Terrain Texture", $"{Const.MORROWIND_PATH}{Const.TERRAIN_DEFAULT_TEXTURE}", 65535));   // Default hardcoded terrain texture. Morrowind moment.
+            texturesByIndex = new()
+            {
+                {
+                    DEFAULT_TEXTURE_INDEX, // Default hardcoded terrain texture. Morrowind moment.
+                    new Texture("Default Terrain Texture", $"{Const.MORROWIND_PATH}{Const.TERRAIN_DEFAULT_TEXTURE}", DEFAULT_TEXTURE_INDEX)
+                }
+            };
 
             var landscapeTexturesByIndex = esm.GetAllRecordsByType(ESM.Type.LandscapeTexture)
                 .ToLookup(j => int.Parse(j["index"].ToString()));
 
-            bool HasTexture(ushort id)
+            foreach (ushort index in ltex)
             {
-                foreach (Texture t in textures)
-                {
-                    if (t.index == id) { return true; }
-                }
-                return false;
-            }
+                if (texturesByIndex.ContainsKey(index)) { continue; }
 
-            foreach (ushort id in ltex)
-            {
-                if (HasTexture(id)) { continue; }
-
-                JsonNode ltjson = landscapeTexturesByIndex[id].FirstOrDefault();
+                JsonNode ltjson = landscapeTexturesByIndex[index].FirstOrDefault();
 
                 if (ltjson != null)
                 {
-                    textures.Add(new Texture(ltjson["id"].ToString().ToLower(), $"{Const.MORROWIND_PATH}Data Files\\textures\\{ltjson["file_name"].ToString().ToLower().Substring(0, ltjson["file_name"].ToString().Length - 4)}.dds", id));
+                    texturesByIndex.Add(
+                        index,
+                        new Texture(ltjson["id"].ToString().ToLower(), $"{Const.MORROWIND_PATH}Data Files\\textures\\{ltjson["file_name"].ToString().ToLower().Substring(0, ltjson["file_name"].ToString().Length - 4)}.dds", index)
+                    );
                 }
                 else
                 {
-                    Lort.Log($" ## WARNING ## INVALID LANDSCAPE TEXTURE INDEX IN LANDSCAPE DATA: {id}", Lort.Type.Debug);
+                    Lort.Log($" ## WARNING ## INVALID LANDSCAPE TEXTURE INDEX IN LANDSCAPE DATA: {index}", Lort.Type.Debug);
                 }
             }
 
@@ -232,16 +233,11 @@ namespace JortPob
                         3,
                         2,
                     };
-                void AddTexture(Landscape land, int tex)
+                void AddTexture(Landscape land, ushort tex)
                 {
-                    Texture texture = null;
-                    foreach (Texture t in land.textures)
+                    if (land.texturesByIndex.TryGetValue(tex, out var texture))
                     {
-                        if (t.index == tex) { texture = t; break; }
-                    }
-                    if (texture != null && !textures.Contains(texture))
-                    {
-                        textures.Add(texture);
+                        texturesByIndex.TryAdd(tex, texture);
                     }
                 }
                 for (int ii = 0; ii < adjacents.Length; ii++)
@@ -530,15 +526,13 @@ namespace JortPob
 
         public Texture GetTexture(ushort id)
         {
-            foreach (Texture tex in textures)
+            if (texturesByIndex.TryGetValue(id, out var value))
             {
-                if (tex.index == id)
-                {
-                    return tex;
-                }
+                return value;
             }
+
             Lort.Log($"# ## WARNING ## Missing texture index [{id}] in landscape mesh!", Lort.Type.Debug);
-            return GetTexture(65535);
+            return texturesByIndex[DEFAULT_TEXTURE_INDEX];
         }
 
         public class Mesh

--- a/JortPob/Worker/CellWorker.cs
+++ b/JortPob/Worker/CellWorker.cs
@@ -79,17 +79,18 @@ namespace JortPob.Worker
 
         public static List<List<Cell>> Go(ESM esm)
         {
-            Lort.Log($"Parsing {esm.records[ESM.Type.Cell].Count} cells...", Lort.Type.Main);
-            Lort.NewTask("Parsing Cells", esm.records[ESM.Type.Cell].Count);
+            var cellRecords = esm.GetAllRecordsByType(ESM.Type.Cell).ToList();
+            Lort.Log($"Parsing {cellRecords.Count} cells...", Lort.Type.Main);
+            Lort.NewTask("Parsing Cells", cellRecords.Count);
 
-            int partition = (int)Math.Ceiling(esm.records[ESM.Type.Cell].Count / (float)Const.THREAD_COUNT);
+            int partition = (int)Math.Ceiling(cellRecords.Count / (float)Const.THREAD_COUNT);
             List<CellWorker> workers = new();
 
             for (int i = 0; i < Const.THREAD_COUNT; i++)
             {
                 int start = i * partition;
                 int end = start + partition;
-                CellWorker worker = new(esm, esm.records[ESM.Type.Cell], start, end);
+                CellWorker worker = new(esm, cellRecords, start, end);
                 workers.Add(worker);
             }
 


### PR DESCRIPTION
This PR updates `ESM.cs`, `ESM/Landscape.cs` to use dictionaries where possible. This is to minimize the number of `O(n)` lookups that need to be performed. This doesn't cover all of the linear lookups in ESM, just the more straightforward ones on the JSON records.

It includes a similar optimization to `Landscape`, which was doing essentially the same thing, but using the `index` of the nodes instead.

The main benefit of all this is that the "Parsing Cells" step is now very quick.