### PR TITLE
docs(JortPob): update documentation to include wwise installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,34 +28,40 @@ Pic for reference:
 6. Download this dll that skips regulation.bin file size checks at startup. This is only avaiable in the `?ServerName?` Discord, and the `Elden Scrolls Dev` Discord, for now. Without this the game fails to load. Add it to the `mods` folder you created above.
 https://cdn.discordapp.com/attachments/1410970950895403040/1411525175802990794/regbinmeme.dll?ex=68c17f02&is=68c02d82&hm=ad33ccf3fda7c3acb4b20f15c630b47cdb3128f6649a64c419efd9ce9eb860b7&
 
-8. Edit the settings file and set the paths to your game folders. Here is Nords for reference. Make sure the OUTPUT_PATH goes to the mods folder you just set up.
+7. Download the [AudioKinetic Launcher](https://www.audiokinetic.com/en/wwise/overview/) here. This will require to to create a (free) account.
+
+8. Install the Wwise `Authoring` package for the `Microsoft > Windows` platform. Make note of the target directory.
+
+9. Update the value of `WWISE_PATH` in `settings.json` to point at the location of the `bin` of the `Authoring` tools. It will look something like `C:\Audiokinetic\Wwise2024.1.8.8898\Authoring\x64\Release\bin\`.
+
+10. Edit the settings file and set the paths to your game folders. Here is Nords for reference. Make sure the OUTPUT_PATH goes to the mods folder you just set up.
 <img width="1203" height="241" alt="image" src="https://github.com/user-attachments/assets/4c2df234-4f31-4975-ae97-c4fec46f648e" />
 
-9. Download BSAUnpacker from nexus: https://www.nexusmods.com/skyrimspecialedition/mods/974
+11. Download BSAUnpacker from nexus: https://www.nexusmods.com/skyrimspecialedition/mods/974
 
-10. Run BSAUnpacker, load the Morrowind.BSA from data files and then hit extract all and tell it to ouput to the `Morrowind/Data Files` folder. If done correctly you will have a bunch files in `Morrowind/Data Files/Meshes` like this:
+12. Run BSAUnpacker, load the Morrowind.BSA from data files and then hit extract all and tell it to ouput to the `Morrowind/Data Files` folder. If done correctly you will have a bunch files in `Morrowind/Data Files/Meshes` like this:
 <img width="960" height="755" alt="image" src="https://github.com/user-attachments/assets/6fb8adce-1bf4-426d-914a-233331351aed" />
 
-11. Install Blender: https://studio.blender.org/welcome/
+13. Install Blender: https://studio.blender.org/welcome/
 
-12. Download and install the morrowind blender plugin: https://github.com/Greatness7/io_scene_mw
+14. Download and install the morrowind blender plugin: https://github.com/Greatness7/io_scene_mw
 <img width="1157" height="701" alt="image" src="https://github.com/user-attachments/assets/b9fdd83d-a29f-40d6-bcfc-3af0190f625f" />
 
-13. Download Nord's program NIF2FBX: https://github.com/Nordgaren/NIF2FBX
+15. Download Nord's program NIF2FBX: https://github.com/Nordgaren/NIF2FBX
 
-14. This is a commandline app that converts all nif files in a directory to fbx. Run the program with the parameters: `NIF2FBX.exe "P:\ath\to\blender.exe" "P:\ath\to\morrowwind"`
+16. This is a commandline app that converts all nif files in a directory to fbx. Run the program with the parameters: `NIF2FBX.exe "P:\ath\to\blender.exe" "P:\ath\to\morrowwind"`
 <img width="2754" height="913" alt="image" src="https://github.com/user-attachments/assets/592451c3-cb7b-4af1-8636-fcb2ae0de5c1" />
 
-15. Download Greatness7's program Tes3Conv. **NOTE:** Needs to be version 0.4.0 currently. Newest version not supported yet. https://github.com/Greatness7/tes3conv
+17. Download Greatness7's program Tes3Conv. **NOTE:** Needs to be version 0.4.0 currently. Newest version not supported yet. https://github.com/Greatness7/tes3conv
 
-16. This is another command line tool so run it with parameters: `tes3conv.exe "Data Files\Morrowind.esm" "Data Files\Morrowind.json"`. You should now have a Morrowind.json in the same folder as Morrowind.esm.
+18. This is another command line tool so run it with parameters: `tes3conv.exe "Data Files\Morrowind.esm" "Data Files\Morrowind.json"`. You should now have a Morrowind.json in the same folder as Morrowind.esm.
 <img width="961" height="612" alt="image" src="https://github.com/user-attachments/assets/8343e568-d7ed-4967-8a53-b394dce38e01" />
 
-17. Download UXM and unpack the script folder for Elden Ring. This needs to exist in order to recompile ESD files. https://github.com/Nordgaren/UXM-Selective-Unpack
+19. Download UXM and unpack the script folder for Elden Ring. This needs to exist in order to recompile ESD files. https://github.com/Nordgaren/UXM-Selective-Unpack
 <img width="539" height="634" alt="image" src="https://github.com/user-attachments/assets/ac43e504-4b41-48a7-8f77-8b60c9a189ca" />
 
-18. Run the project in your IDE. It will take a while to build.
+20. Run the project in your IDE. It will take a while to build.
 
-19. Double click the `elden-scrolls.me3` file to run the game. Go to the church of elleh and you will be transports to Morrowwind.
+21. Double click the `elden-scrolls.me3` file to run the game. Go to the church of elleh and you will be transports to Morrowwind.
 
 You can use [Elden Ring Debug Tool](https://github.com/Nordgaren/Elden-Ring-Debug-Tool) or the [TGA Table](https://github.com/The-Grand-Archives/Elden-Ring-CT-TGA) to warp to the Church of Elleh and spawn items in. The latter requires Cheat Engine.


### PR DESCRIPTION
This PR updates the README to include steps for installing the Wwise Authoring tools. Here are some extra screenshots that may be helpful to add once it lands:

Screenshot of Audiokinetic Launcher showing the package to install:
<img width="1085" height="858" alt="image" src="https://github.com/user-attachments/assets/f516c01c-7883-4949-adfd-bd8a31454ac1" />


Updated `settings.json` (also includes `LOAD_ORDER`), which would replace the screenshot for step `10`.
<img width="722" height="239" alt="image" src="https://github.com/user-attachments/assets/76197366-4c18-4bcf-bf3a-089ccbaf978b" />