### PR TITLE
refactor(Layout): part 1 of layout constructor refactor

### DIFF
--- a/JortPob/BigTile.cs
+++ b/JortPob/BigTile.cs
@@ -82,6 +82,11 @@ namespace JortPob
             return null;
         }
         
+        /**
+         * We double the coordinates from the `BigTile` center to approximate its shape, then check each of
+         * the `tilesToAdd` to see if it is entirely contained within the BigTile (with a little padding),
+         * and add any that are fully contained.
+         */
         public void AddMatchingTiles(IEnumerable<Tile> tilesToAdd)
         {
             var x1 = coordinate.x * 2;

--- a/JortPob/BigTile.cs
+++ b/JortPob/BigTile.cs
@@ -1,5 +1,4 @@
 ﻿using JortPob.Common;
-using SoulsFormats.Formats.Morpheme.MorphemeBundle;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Numerics;
@@ -82,11 +81,22 @@ namespace JortPob
             }
             return null;
         }
-
-        public void AddTile(Tile tile)
+        
+        public void AddMatchingTiles(IEnumerable<Tile> tilesToAdd)
         {
-            tiles.Add(tile);
-            tile.big = this;
+            var x1 = coordinate.x * 2;
+            var y1 = coordinate.y * 2;
+            var x2 = x1 + 2;
+            var y2 = y1 + 2;
+
+            foreach (var tile in tilesToAdd)
+            {
+                if (tile.coordinate.x >= x1 && tile.coordinate.x < x2 && tile.coordinate.y >= y1 && tile.coordinate.y < y2)
+                {
+                    tiles.Add(tile);
+                    tile.big = this;
+                }
+            }
         }
     }
 }

--- a/JortPob/BigTile.cs
+++ b/JortPob/BigTile.cs
@@ -82,25 +82,12 @@ namespace JortPob
             return null;
         }
         
-        /**
-         * We double the coordinates from the `BigTile` center to approximate its shape, then check each of
-         * the `tilesToAdd` to see if it is entirely contained within the BigTile (with a little padding),
-         * and add any that are fully contained.
-         */
         public void AddMatchingTiles(IEnumerable<Tile> tilesToAdd)
         {
-            var x1 = coordinate.x * 2;
-            var y1 = coordinate.y * 2;
-            var x2 = x1 + 2;
-            var y2 = y1 + 2;
-
-            foreach (var tile in tilesToAdd)
+            foreach (var tile in FilterTilesToAdd(tilesToAdd, 2, 2))
             {
-                if (tile.coordinate.x >= x1 && tile.coordinate.x < x2 && tile.coordinate.y >= y1 && tile.coordinate.y < y2)
-                {
-                    tiles.Add(tile);
-                    tile.big = this;
-                }
+                tiles.Add(tile);
+                tile.big = this;
             }
         }
     }

--- a/JortPob/ESM/Content.cs
+++ b/JortPob/ESM/Content.cs
@@ -684,6 +684,16 @@ namespace JortPob
                 warp = new(json["destination"]);
             }
         }
+
+        public void ApplyWarpParams(int map, int x, int y, int block, uint warpEntity, string prompt)
+        {
+            warp.map = map;
+            warp.x = x;
+            warp.y = y;
+            warp.block = block;
+            warp.entity = warpEntity;
+            warp.prompt = prompt;
+        }
     }
 
     /* static mesh of a container in the world that can **CAN** (but not always) be lootable */

--- a/JortPob/ESM/Content.cs
+++ b/JortPob/ESM/Content.cs
@@ -141,6 +141,13 @@ namespace JortPob
             {
                 cost = 100;
             }
+
+            public void ApplyParams(int map, int x, int y, int block, uint entity, string name, int cost)
+            {
+                ApplyParams(map, x, y, block, entity, prompt);
+                this.name = name;
+                this.cost = cost;
+            }
         }
 
         public class Stats
@@ -671,6 +678,16 @@ namespace JortPob
                 cell = json["cell"].ToString().Trim();
                 if (cell == "") { cell = null; }
             }
+
+            public void ApplyParams(int map, int x, int y, int block, uint entity, string prompt)
+            {
+                this.map = map;
+                this.x = x;
+                this.y = y;
+                this.block = block;
+                this.entity = entity;
+                this.prompt = prompt;
+            }
         }
 
         public Warp warp;
@@ -687,12 +704,7 @@ namespace JortPob
 
         public void ApplyWarpParams(int map, int x, int y, int block, uint warpEntity, string prompt)
         {
-            warp.map = map;
-            warp.x = x;
-            warp.y = y;
-            warp.block = block;
-            warp.entity = warpEntity;
-            warp.prompt = prompt;
+            warp.ApplyParams(map, x, y, block, warpEntity, prompt);
         }
     }
 

--- a/JortPob/ESM/ESM.cs
+++ b/JortPob/ESM/ESM.cs
@@ -455,7 +455,71 @@ namespace JortPob
             hasDialogCache.Add(content.id, false);
             return false;
         }
+        
+        public ScriptReferenceMetadata GetScriptReferences()
+        {
+            /* Find all objects targeted by script calls so we can make sure they are placd in regular tiles. Objects in Big/Huge tiles can't have script data */
+            IEnumerable<Papyrus.Call> allCalls = scripts
+                .SelectMany(p => p.GetCalls())
+                .Concat(dialog.SelectMany(d => d.GetCalls()));
+
+            HashSet<string> allReferences = [], toggleableRefs = [];  // able refs is objects targeted by Enable, Disable, and GetDisabled
+
+            foreach (Papyrus.Call call in allCalls)
+            {
+                // Grab record reference from target if exists
+                if (call.target != null && call.target != "player")
+                {
+                    allReferences.Add(call.target);
+
+                    switch (call.type)
+                    {
+                        case Papyrus.Call.Type.Enable:
+                        case Papyrus.Call.Type.Disable:
+                        case Papyrus.Call.Type.GetDisabled:
+                            toggleableRefs.Add(call.target);
+                            break;
+                        default: break;
+                    }
+                }
+
+                // Grab record reference from arguments if they exist
+                switch (call.type)
+                {
+                    case Papyrus.Call.Type.Cast:
+                        {
+                            string reference = call.parameters[1].ToLower().Trim();
+                            if (reference == "player") { break; }
+                            allReferences.Add(reference);
+                            break;
+                        }
+                    case Papyrus.Call.Type.GetDistance:
+                        {
+                            string reference = call.parameters[0].ToLower().Trim();
+                            if (reference == "player") { break; }
+                            allReferences.Add(reference);
+                            break;
+                        }
+                    default: break;
+                }
+            }
+
+            toggleableRefs.UnionWith(
+                exterior.Concat(interior).SelectMany(cell => cell.contents)
+                    .Where(content => {
+                        var papyrus = GetPapyrus(content.papyrus);
+                        return papyrus != null && (papyrus.HasCall(Papyrus.Call.Type.Disable) ||
+                                                   papyrus.HasCall(Papyrus.Call.Type.Enable) ||
+                                                   papyrus.HasCall(Papyrus.Call.Type.GetDisabled));
+                    })
+                    .Select(content => content.id.ToLower().Trim())
+            );
+
+            return new ScriptReferenceMetadata(allReferences, toggleableRefs);
+        }
     }
+
+    public record ScriptReferenceMetadata(HashSet<string> AllReferences, HashSet<string> ToggleableReferences);
 
     public class RegionInfo
     {

--- a/JortPob/ESM/ESM.cs
+++ b/JortPob/ESM/ESM.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Text.Json.Nodes;
 using static JortPob.Dialog;
 

--- a/JortPob/FxrManager.cs
+++ b/JortPob/FxrManager.cs
@@ -162,7 +162,7 @@ namespace JortPob
             [
                 60, // for the overworld
             ];
-            foreach(InteriorGroup group in layout.interiors)
+            foreach(InteriorGroup group in layout.Interiors)
             {
                 if (group.IsEmpty()) { continue; }
                 if (maps.Contains(group.map)) { continue; }

--- a/JortPob/HugeTile.cs
+++ b/JortPob/HugeTile.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
+using HKLib.hk2018.hkcdStaticMeshTree;
 
 namespace JortPob
 {
@@ -118,6 +119,35 @@ namespace JortPob
         {
             bigs.Add(big);
             big.huge = this;
+        }
+        
+        public void AddMatchingTiles(IEnumerable<Tile> tilesToAdd)
+        {
+            foreach (var tile in FilterTilesToAdd(tilesToAdd, 4, 4))
+            {
+                tiles.Add(tile);
+                tile.huge = this;
+            }
+        }
+
+        public void AddMatchingTiles(IEnumerable<BigTile> tilesToAdd)
+        {
+            foreach (var tile in FilterTilesToAdd(tilesToAdd, 2, 2))
+            {
+                bigs.Add(tile);
+                tile.huge = this;
+            }
+        }
+
+        private IEnumerable<T> FilterTilesToAdd<T>(IEnumerable<T> tilesToAdd, int scaleFactor, int padding) where T: BaseTile
+        {
+            var x1 = coordinate.x * scaleFactor;
+            var y1 = coordinate.y * scaleFactor;
+            var x2 = x1 + padding;
+            var y2 = y1 + padding;
+
+            return tilesToAdd.Where(t =>
+                t.coordinate.x >= x1 && t.coordinate.x < x2 && t.coordinate.y >= y1 && t.coordinate.y < y2);
         }
 
         public void AddTile(Tile tile)

--- a/JortPob/HugeTile.cs
+++ b/JortPob/HugeTile.cs
@@ -139,17 +139,6 @@ namespace JortPob
             }
         }
 
-        private IEnumerable<T> FilterTilesToAdd<T>(IEnumerable<T> tilesToAdd, int scaleFactor, int padding) where T: BaseTile
-        {
-            var x1 = coordinate.x * scaleFactor;
-            var y1 = coordinate.y * scaleFactor;
-            var x2 = x1 + padding;
-            var y2 = y1 + padding;
-
-            return tilesToAdd.Where(t =>
-                t.coordinate.x >= x1 && t.coordinate.x < x2 && t.coordinate.y >= y1 && t.coordinate.y < y2);
-        }
-
         public void AddTile(Tile tile)
         {
             tiles.Add(tile);

--- a/JortPob/Layout.cs
+++ b/JortPob/Layout.cs
@@ -87,23 +87,6 @@ namespace JortPob
             Lort.TaskIterate(); // Progress bar update
 
             /* Subdivide all cell content into tiles */
-            Content EmitterConversionCheck(Content content)
-            {
-                if (content.GetType() != typeof(AssetContent)) { return content; }
-                AssetContent assetContent = content as AssetContent;
-
-                /* If an assetcontent has emitter nodes, we convert it to an emittercontent */
-                /* We can't really do this earlier than this point sadly because we need both the ESM loaded an cache built to be able to catch this corner case */
-                /* So we do it here */
-                ModelInfo modelInfo = cache.GetModel(assetContent.mesh);
-                if (!modelInfo.HasEmitter()) { return content; }
-
-                EmitterContent emitterContent = assetContent.ConvertToEmitter();
-                cache.AddConvertedEmitter(emitterContent);
-
-                return emitterContent;
-            }
-
             foreach (Cell cell in esm.exterior)
             {
                 HugeTile huge = GetHugeTile(cell.center);
@@ -120,9 +103,18 @@ namespace JortPob
 
                     foreach (Content content in cell.contents)
                     {
-                        Content c = EmitterConversionCheck(content); // checks if we need to convert an assetcontent into an emittercontent due to it having emitter nodes but no light data
+                        if (content is AssetContent assetContent)
+                        {
+                            /* If an assetcontent has emitter nodes, we convert it to an emittercontent */
+                            /* We can't really do this earlier than this point sadly because we need both the ESM loaded and cache built to be able to catch this corner case */
+                            /* So we do it here */
+                            if (cache.GetModel(assetContent.mesh)?.HasEmitter() == true)
+                            {
+                                cache.AddConvertedEmitter(assetContent.ConvertToEmitter());
+                            }
+                        }
 
-                        huge.AddContent(cache, cell, c, allReferences.Contains(content.id.ToLower().Trim()));
+                        huge.AddContent(cache, cell, content, allReferences.Contains(content.id.ToLower().Trim()));
                     }
                 }
                 else { Lort.Log($" ## WARNING ## Cell fell outside of reality [{cell.coordinate.x}, {cell.coordinate.y}] -- {cell.name} :: B02", Lort.Type.Debug); }
@@ -186,65 +178,9 @@ namespace JortPob
                     scriptManager.areas.Add(cell, script.CreateEntity(Script.EntityType.Region, $"cell {cell.name}"));
                 }
             }
-
             Lort.TaskIterate(); // Progress bar update
 
             /* Resolve load doors and travel npcs */
-            Cell FindCell(Vector3 position)  // getting an ext cell by morrowind coordinates. used to find exterior cell name
-            {
-                int x = (int)Math.Floor(position.X / Const.CELL_SIZE);
-                int y = (int)Math.Floor(position.Z / Const.CELL_SIZE);
-                return esm.GetCellByGrid(new Int2(x, y));
-            }
-
-            void HandleTravel(NpcContent npc, Tile from = null)
-            {
-                if (npc.travel.Count() > 0)
-                {
-                    // Travel goes to interior cell
-                    for (int i = 0; i < npc.travel.Count; i++)
-                    {
-                        CharacterContent.Travel travel = npc.travel[i];
-                        if (travel.cell != null)
-                        {
-                            InteriorGroup.Chunk to = FindChunk(travel.cell);
-                            if (to == null) { npc.travel.RemoveAt(i--); continue; }      // caused by debug sometimes
-                            travel.map = to.group.map;
-                            travel.x = to.group.area;
-                            travel.y = to.group.unk;
-                            travel.block = to.group.block;
-                            travel.entity = scriptManager.GetScript(to.group).CreateEntity(Script.EntityType.Region, $"TravelDestination::{npc.cell.name}->{travel.cell}");
-                            travel.name = to.cell.name;
-                            travel.cost = Const.TRAVEL_DEFAULT_COST;
-
-                            to.AddWarp(travel);
-                        }
-                        // Travel goes to exterior cell
-                        else
-                        {
-                            Tile to = FindTile(travel.position);  // does not respect cell borders in tile msbs. likely a non-issue but kinda sketch ... @TODO:
-                            Cell cell = FindCell(travel.position);
-                            if (to == null || cell == null) { npc.travel.RemoveAt(i--); continue; }     // caused by debug sometimes
-                            travel.map = to.map;
-                            travel.x = to.coordinate.x;
-                            travel.y = to.coordinate.y;
-                            travel.block = to.block;
-                            travel.entity = scriptManager.GetScript(to).CreateEntity(Script.EntityType.Region, $"TravelDestination::{npc.cell.name}->exterior[{travel.x},{travel.y}]");
-                            travel.name = cell.name;
-                            // calculate distance for cost of travel
-                            if (from != null)
-                            {
-                                Vector2 a = new(from.coordinate.x, from.coordinate.y);
-                                Vector2 b = new(to.coordinate.x, to.coordinate.y);
-                                travel.cost = (int)(Const.TRAVEL_DISTANCE_COST * Math.Max(1, Vector2.Distance(a, b)));
-                            }
-                            else { travel.cost = Const.TRAVEL_DEFAULT_COST; }
-                            to.AddWarp(travel);
-                        }
-                    }
-                }
-            }
-
             foreach (InteriorGroup group in interiors)
             {
                 foreach (InteriorGroup.Chunk chunk in group.chunks)
@@ -257,7 +193,7 @@ namespace JortPob
 
                     foreach (NpcContent npc in chunk.npcs)
                     {
-                        HandleTravel(npc);
+                        RegisterNpcWarp(esm, scriptManager, npc);
                     }
                 }
             }
@@ -272,7 +208,7 @@ namespace JortPob
 
                 foreach (NpcContent npc in tile.npcs)
                 {
-                    HandleTravel(npc, tile);
+                    RegisterNpcWarp(esm, scriptManager, npc, tile);
                 }
             }
             Lort.TaskIterate(); // Progress bar update
@@ -925,7 +861,45 @@ namespace JortPob
                 to.AddWarp(door.warp);
             }
         }
-        
+
+        private void RegisterNpcWarp(ESM esm, ScriptManager scriptManager, NpcContent npc, Tile from = null)
+        {
+            if (npc.travel.Count <= 0) return;
+
+            // Travel goes to interior cell
+            for (int i = 0; i < npc.travel.Count; i++)
+            {
+                var travel = npc.travel[i];
+                if (travel.cell != null)
+                {
+                    var to = FindChunk(travel.cell);
+                    if (to == null) { npc.travel.RemoveAt(i--); continue; }      // caused by debug sometimes
+                    var entity = scriptManager.GetScript(to.group).CreateEntity(Script.EntityType.Region, $"TravelDestination::{npc.cell.name}->{travel.cell}");
+                    travel.ApplyParams(to.group.map, to.group.area, to.group.unk, to.group.block, entity, to.cell.name, Const.TRAVEL_DEFAULT_COST);
+                    to.AddWarp(travel);
+                }
+                // Travel goes to exterior cell
+                else
+                {
+                    var to = FindTile(travel.position);  // does not respect cell borders in tile msbs. likely a non-issue but kinda sketch ... @TODO:
+                    var cell = esm.GetCellByPosition(travel.position); // this should be safe, assuming travel.position is a Morrowind coordinate
+                    if (to == null || cell == null) { npc.travel.RemoveAt(i--); continue; }     // caused by debug sometimes
+                    var entity = scriptManager.GetScript(to).CreateEntity(Script.EntityType.Region, $"TravelDestination::{npc.cell.name}->exterior[{travel.x},{travel.y}]");
+                    int cost;
+                    // calculate distance for cost of travel
+                    if (from != null)
+                    {
+                        Vector2 a = new(from.coordinate.x, from.coordinate.y);
+                        Vector2 b = new(to.coordinate.x, to.coordinate.y);
+                        cost = (int)(Const.TRAVEL_DISTANCE_COST * Math.Max(1, Vector2.Distance(a, b)));
+                    }
+                    else { cost = Const.TRAVEL_DEFAULT_COST; }
+                    travel.ApplyParams(to.map, to.coordinate.x, to.coordinate.y, to.block, entity, cell.name, cost);
+                    to.AddWarp(travel);
+                }
+            }
+        }
+
         public HugeTile GetHugeTile(Vector3 position)
         {
             foreach (HugeTile huge in huges)

--- a/JortPob/Layout.cs
+++ b/JortPob/Layout.cs
@@ -1016,7 +1016,7 @@ namespace JortPob
             }
 
             // merge similar
-            List<string> pointNames = new();
+            HashSet<string> pointNames = new();
             List<MapPoint> importants = new();
             foreach(var kvp in mapPoints)
             {
@@ -1031,7 +1031,7 @@ namespace JortPob
                     center += pos;
                 }
 
-                center = center * (1f / kvp.Value.Count());
+                center *= (1f / kvp.Value.Count());
 
                 MapPoint.Icon icon = Override.GetMapIcon(name);
                 if (icon == MapPoint.Icon.None) { continue; }  // skip these
@@ -1041,23 +1041,6 @@ namespace JortPob
                 tile.AddMapPoint(mapPoint);
                 importants.Add(mapPoint);
                 pointNames.Add(name.ToLower().Trim());
-            }
-
-            // Search for interior doors to add markers for
-            bool IsInsideImportant(Vector3 position)  // checks if a position is inside of one of the important map points we created above. returns true if it is
-            {
-                foreach(MapPoint important in importants)
-                {
-                    if (Vector3.Distance(position, important.position) <= important.radius) { return true; }
-                }
-                return false;
-            }
-
-            bool AlreadyExists(string name)  // see if map point has already been made. some areas have multiple entrances or exits
-            {
-                if(pointNames.Contains(name.ToLower().Trim())) { return true; }
-                pointNames.Add(name.ToLower().Trim());
-                return false;
             }
 
             foreach(Tile tile in tiles)
@@ -1071,8 +1054,14 @@ namespace JortPob
                         MapPoint.Icon icon = Override.GetMapIcon(name);
 
                         if (icon == MapPoint.Icon.None) { continue; }  // skip these
-                        if (IsInsideImportant(door.position)) { continue; } // skip these too!
-                        if (AlreadyExists(name)) { continue; }    // skip this one as well!
+
+                        // checks if a position is inside of one of the important map points we created above. skip these too!
+                        if (importants.Any(p => Vector3.Distance(door.position, p.position) <= p.radius)) {  continue; }
+
+                        // see if map point has already been made. some areas have multiple entrances or exits
+                        var lowerName = name.ToLower().Trim();
+                        if(pointNames.Contains(lowerName)) { continue; }
+                        pointNames.Add(lowerName);
 
                         const float UNIMPORTANT_SIZE_MODIFIER = 0.3f;
                         Script.Flag discoverFlag = scriptManager.common.CreateFlag(Script.Flag.Category.Saved, Script.Flag.Type.Bit, Script.Flag.Designation.DiscoverLocation, name); // if 2 doors go to the same interior we share the flag

--- a/JortPob/Layout.cs
+++ b/JortPob/Layout.cs
@@ -2,6 +2,7 @@
 using Microsoft.Windows.Themes;
 using SoulsFormats;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -13,22 +14,23 @@ namespace JortPob
     /* Takes the Morrowind ESM cell grid and re-subdivides it into the Elden Ring tile grid */
     public class Layout
     {
-        public List<BaseTile> all;
-        public List<HugeTile> huges;
-        public List<BigTile> bigs;
-        public List<Tile> tiles;
+        private readonly List<HugeTile> huges = [];
+        private readonly List<BigTile> bigs = [];
+        private readonly List<Tile> tiles = [];
 
-        public List<InteriorGroup> interiors;
+        private readonly List<InteriorGroup> interiors = [];
+
+        // For now, we just expose IEnumerable in case we need to change the underlying implementation
+        public IEnumerable<BaseTile> AllTiles => new IEnumerable<BaseTile>[]{tiles, bigs, huges}.SelectMany(t => t);
+
+        public IEnumerable<Tile> Tiles => tiles;
+        public int TileCount => tiles.Count;
+
+        public IEnumerable<InteriorGroup> Interiors => interiors;
+        public int InteriorCount => interiors.Count;
 
         public Layout(Cache cache, ESM esm, Paramanager param, TextManager text, ScriptManager scriptManager)
         {
-            all = new();
-            huges = new();
-            bigs = new();
-            tiles = new();
-
-            interiors = new();
-
             Lort.Log("Generating layout...", Lort.Type.Main);
             Lort.NewTask("Generating Layout", 14);
 
@@ -47,7 +49,6 @@ namespace JortPob
                 {
                     Tile tile = new Tile(m, x, y, b);
                     tiles.Add(tile);
-                    all.Add(tile);
                 }
             }
             Lort.TaskIterate(); // Progress bar update
@@ -77,7 +78,6 @@ namespace JortPob
                     }
 
                     bigs.Add(big);
-                    all.Add(big);
                 }
             }
             Lort.TaskIterate(); // Progress bar update
@@ -119,7 +119,6 @@ namespace JortPob
                     }
 
                     huges.Add(huge);
-                    all.Add(huge);
                 }
             }
             Lort.TaskIterate(); // Progress bar update
@@ -1061,6 +1060,7 @@ namespace JortPob
                 to.AddWarp(door.warp);
             }
         }
+        
         public HugeTile GetHugeTile(Vector3 position)
         {
             foreach (HugeTile huge in huges)

--- a/JortPob/Layout.cs
+++ b/JortPob/Layout.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using Microsoft.Scripting.Utils;
 using static JortPob.InteriorGroup;
 
 namespace JortPob
@@ -14,9 +15,11 @@ namespace JortPob
     /* Takes the Morrowind ESM cell grid and re-subdivides it into the Elden Ring tile grid */
     public class Layout
     {
+        private static readonly int MapId = 60;
+
         private readonly List<HugeTile> huges = [];
         private readonly List<BigTile> bigs = [];
-        private readonly List<Tile> tiles = [];
+        private readonly List<Tile> tiles;
 
         private readonly List<InteriorGroup> interiors = [];
 
@@ -38,110 +41,44 @@ namespace JortPob
             string msbdata = File.ReadAllText(Utility.ResourcePath(@"msb\msblist.txt"));
             string[][] msblist = msbdata.Split(";").Select(msb => msb.Split(",")).ToArray();
 
-            foreach (string[] split in msblist)
-            {
-                int m = int.Parse(split[0]);
-                int x = int.Parse(split[1]);
-                int y = int.Parse(split[2]);
-                int b = int.Parse(split[3]);
+            tiles = ProcessMsbList(msblist)
+                .Where(t => t.b == 0 && t.m == MapId)
+                .Select(t => new Tile(t.m, t.x, t.y, t.b))
+                .ToList();
 
-                if (m == 60 && b == 0)
-                {
-                    Tile tile = new Tile(m, x, y, b);
-                    tiles.Add(tile);
-                }
-            }
             Lort.TaskIterate(); // Progress bar update
-
+            
             /* Generate BigTiles... */
-            foreach (string[] split in msblist)
+            foreach (var (m, x, y, b) in ProcessMsbList(msblist))
             {
-                int m = int.Parse(split[0]);
-                int x = int.Parse(split[1]);
-                int y = int.Parse(split[2]);
-                int b = int.Parse(split[3]);
-
-                if (m == 60 && b == 1)
-                {
-                    BigTile big = new BigTile(m, x, y, b);
-
-                    foreach (Tile tile in tiles)
-                    {
-                        int x1 = x * 2;
-                        int y1 = y * 2;
-                        int x2 = x1 + 2;
-                        int y2 = y1 + 2;
-                        if (tile.coordinate.x >= x1 && tile.coordinate.x < x2 && tile.coordinate.y >= y1 && tile.coordinate.y < y2)
-                        {
-                            big.AddTile(tile);
-                        }
-                    }
-
-                    bigs.Add(big);
-                }
+                if (m != MapId || b != 1) continue;
+                BigTile big = new(m, x, y, b);
+                big.AddMatchingTiles(tiles);
+                bigs.Add(big);
             }
             Lort.TaskIterate(); // Progress bar update
 
             /* Generate HugeTiles... */
-            foreach (string[] split in msblist)
+            foreach (var (m, x, y, b) in ProcessMsbList(msblist))
             {
-                int m = int.Parse(split[0]);
-                int x = int.Parse(split[1]);
-                int y = int.Parse(split[2]);
-                int b = int.Parse(split[3]);
-
-                if (m == 60 && b == 2)
-                {
-                    HugeTile huge = new HugeTile(m, x, y, b);
-
-                    foreach (BigTile big in bigs)
-                    {
-                        int x1 = x * 2;
-                        int y1 = y * 2;
-                        int x2 = x1 + 2;
-                        int y2 = y1 + 2;
-                        if (big.coordinate.x >= x1 && big.coordinate.x < x2 && big.coordinate.y >= y1 && big.coordinate.y < y2)
-                        {
-                            huge.AddBig(big);
-                        }
-                    }
-
-                    foreach (Tile tile in tiles)
-                    {
-                        int x1 = x * 4;
-                        int y1 = y * 4;
-                        int x2 = x1 + 4;
-                        int y2 = y1 + 4;
-                        if (tile.coordinate.x >= x1 && tile.coordinate.x < x2 && tile.coordinate.y >= y1 && tile.coordinate.y < y2)
-                        {
-                            huge.AddTile(tile);
-                        }
-                    }
-
-                    huges.Add(huge);
-                }
+                if (m != MapId || b != 2) continue;
+                HugeTile huge = new(m, x, y, b);
+                huge.AddMatchingTiles(bigs);
+                huge.AddMatchingTiles(tiles);
+                huges.Add(huge);
             }
             Lort.TaskIterate(); // Progress bar update
 
             /* Generate Interior Groups */
-            foreach (string[] split in msblist)
-            {
-                int m = int.Parse(split[0]);
-                int a = int.Parse(split[1]);
-                int u = int.Parse(split[2]);
-                int b = int.Parse(split[3]);
-
-                int[] validMaps = new int[]
-                {
-                    12, 13, 14, 15, 16, 19, 20, 21, 22, 25, 28, 30, 31, 32, 34, 35, 39, 40, 41, 42, 43
-                };
-
-                if (validMaps.Contains(m) && u == 0 && b == 0)
-                {
-                    InteriorGroup group = new InteriorGroup(m, a, u, b);
-                    interiors.Add(group);
-                }
-            }
+            HashSet<int> validMaps =
+                [12, 13, 14, 15, 16, 19, 20, 21, 22, 25, 28, 30, 31, 32, 34, 35, 39, 40, 41, 42, 43];
+            interiors = ProcessMsbList(msblist)
+                .Where(t => t is { y: 0, b: 0 } && validMaps.Contains(t.m))
+                .Select(t => {
+                    var (m, a, u, b) = t;
+                    return new InteriorGroup(m, a, u, b);
+                })
+                .ToList();
             Lort.TaskIterate(); // Progress bar update
 
             /* Part 1 of papyrus pre-process */
@@ -1308,6 +1245,18 @@ namespace JortPob
                 if (Vector3.Distance(content.relative, p.position) <= radius * Const.GLOBAL_SCALE) { result.Add(p); }
             }
             return result;
+        }
+
+        private static IEnumerable<(int m, int x, int y, int b)> ProcessMsbList(string[][] msblist)
+        {
+            foreach (var split in msblist)
+            {
+                var m = int.Parse(split[0]);
+                var x = int.Parse(split[1]);
+                var y = int.Parse(split[2]);
+                var b = int.Parse(split[3]);
+                yield return (m, x, y, b);
+            }
         }
 
         public class MapPoint

--- a/JortPob/Layout.cs
+++ b/JortPob/Layout.cs
@@ -333,42 +333,6 @@ namespace JortPob
                 return esm.GetCellByGrid(new Int2(x, y));
             }
 
-            void HandleDoor(DoorContent door)
-            {
-                if (door.warp != null)
-                {
-                    // Door goes to interior cell
-                    if (door.warp.cell != null)
-                    {
-                        InteriorGroup.Chunk to = FindChunk(door.warp.cell);
-                        if (to == null) { door.warp = null; return; }      // caused by debug sometimes
-                        door.warp.map = to.group.map;
-                        door.warp.x = to.group.area;
-                        door.warp.y = to.group.unk;
-                        door.warp.block = to.group.block;
-                        door.warp.entity = scriptManager.GetScript(to.group).CreateEntity(Script.EntityType.Region, $"DoorExit::{door.cell.name}->{door.warp.cell}");
-                        string areaName;
-                        if (to.cell.name.Contains(",")) { areaName = to.cell.name.Split(",")[^1].Trim(); }
-                        else { areaName = to.cell.name; }
-                        door.warp.prompt = $"Enter {areaName}";
-                        to.AddWarp(door.warp);
-                    }
-                    // Door goes to exterior cell
-                    else
-                    {
-                        Tile to = FindTile(door.warp.position);  // does not respect cell borders in tile msbs. likely a non-issue but kinda sketch ... @TODO:
-                        if (to == null) { door.warp = null; return; }     // caused by debug sometimes
-                        door.warp.map = to.map;
-                        door.warp.x = to.coordinate.x;
-                        door.warp.y = to.coordinate.y;
-                        door.warp.block = to.block;
-                        door.warp.entity = scriptManager.GetScript(to).CreateEntity(Script.EntityType.Region, $"DoorExit::{door.cell.name}->exterior[{door.warp.x},{door.warp.y}]");
-                        door.warp.prompt = $"Exit";
-                        to.AddWarp(door.warp);
-                    }
-                }
-            }
-
             void HandleTravel(NpcContent npc, Tile from = null)
             {
                 if (npc.travel.Count() > 0)
@@ -423,7 +387,7 @@ namespace JortPob
                 {
                     foreach (DoorContent door in chunk.doors)
                     {
-                        HandleDoor(door);
+                        RegisterDoorWarp(door, scriptManager);
                         if (door.warp != null) { door.entity = scriptManager.GetScript(group).CreateEntity(Script.EntityType.Asset, $"DoorEntry::{door.cell.name}->{door.warp.cell}"); }
                     }
 
@@ -438,7 +402,7 @@ namespace JortPob
             {
                 foreach (DoorContent door in tile.doors)
                 {
-                    HandleDoor(door);
+                    RegisterDoorWarp(door, scriptManager);
                     if (door.warp != null) { door.entity = scriptManager.GetScript(tile).CreateEntity(Script.EntityType.Asset, $"DoorExit::{door.cell.name}->exterior[{door.warp.x},{door.warp.y}]"); }
                 }
 
@@ -1073,6 +1037,30 @@ namespace JortPob
             Lort.TaskIterate(); // Progress bar update
         }
 
+        private void RegisterDoorWarp(DoorContent door, ScriptManager scriptManager)
+        {
+            if (door.warp == null) { return; }
+
+            // Door goes to interior cell
+            if (door.warp.cell != null)
+            {
+                InteriorGroup.Chunk to = FindChunk(door.warp.cell);
+                if (to == null) { door.warp = null; return; }      // caused by debug sometimes
+                string areaName = to.cell.name.Contains(",") ? to.cell.name.Split(",")[^1].Trim() : to.cell.name;
+                uint entity = scriptManager.GetScript(to.group).CreateEntity(Script.EntityType.Region, $"DoorExit::{door.cell.name}->{door.warp.cell}");
+                door.ApplyWarpParams(to.group.map, to.group.area, to.group.unk, to.group.block,  entity, $"Enter {areaName}");
+                to.AddWarp(door.warp);
+            }
+            // Door goes to exterior cell
+            else
+            {
+                Tile to = FindTile(door.warp.position);  // does not respect cell borders in tile msbs. likely a non-issue but kinda sketch ... @TODO:
+                if (to == null) { door.warp = null; return; }     // caused by debug sometimes
+                uint entity = scriptManager.GetScript(to).CreateEntity(Script.EntityType.Region, $"DoorExit::{door.cell.name}->exterior[{door.warp.x},{door.warp.y}]"); 
+                door.ApplyWarpParams(to.map, to.coordinate.x, to.coordinate.y,  to.block, entity,  $"Exit");
+                to.AddWarp(door.warp);
+            }
+        }
         public HugeTile GetHugeTile(Vector3 position)
         {
             foreach (HugeTile huge in huges)

--- a/JortPob/Layout.cs
+++ b/JortPob/Layout.cs
@@ -34,11 +34,10 @@ namespace JortPob
 
             /* Generate tiles based off base game msb info... */
             string msbdata = File.ReadAllText(Utility.ResourcePath(@"msb\msblist.txt"));
-            string[] msblist = msbdata.Split(";");
+            string[][] msblist = msbdata.Split(";").Select(msb => msb.Split(",")).ToArray();
 
-            foreach (string msb in msblist)
+            foreach (string[] split in msblist)
             {
-                string[] split = msb.Split(",");
                 int m = int.Parse(split[0]);
                 int x = int.Parse(split[1]);
                 int y = int.Parse(split[2]);
@@ -54,9 +53,8 @@ namespace JortPob
             Lort.TaskIterate(); // Progress bar update
 
             /* Generate BigTiles... */
-            foreach (string msb in msblist)
+            foreach (string[] split in msblist)
             {
-                string[] split = msb.Split(",");
                 int m = int.Parse(split[0]);
                 int x = int.Parse(split[1]);
                 int y = int.Parse(split[2]);
@@ -85,9 +83,8 @@ namespace JortPob
             Lort.TaskIterate(); // Progress bar update
 
             /* Generate HugeTiles... */
-            foreach (string msb in msblist)
+            foreach (string[] split in msblist)
             {
-                string[] split = msb.Split(",");
                 int m = int.Parse(split[0]);
                 int x = int.Parse(split[1]);
                 int y = int.Parse(split[2]);
@@ -128,9 +125,8 @@ namespace JortPob
             Lort.TaskIterate(); // Progress bar update
 
             /* Generate Interior Groups */
-            foreach (string msb in msblist)
+            foreach (string[] split in msblist)
             {
-                string[] split = msb.Split(",");
                 int m = int.Parse(split[0]);
                 int a = int.Parse(split[1]);
                 int u = int.Parse(split[2]);

--- a/JortPob/Layout.cs
+++ b/JortPob/Layout.cs
@@ -82,80 +82,8 @@ namespace JortPob
             Lort.TaskIterate(); // Progress bar update
 
             /* Part 1 of papyrus pre-process */
-            /* Find all objects targeted by script calls so we can make sure they are placd in regular tiles. Objects in Big/Huge tiles can't have script data */
-            List<Papyrus.Call> allCalls = new();
-            foreach (Papyrus papyrus in esm.scripts)
-            {
-                allCalls.AddRange(papyrus.GetCalls());
-            }
-
-            foreach (Dialog.DialogRecord dialog in esm.dialog)
-            {
-                allCalls.AddRange(dialog.GetCalls());
-            }
-
-            List<string> allReferences = new(), ableReferences = new();  // able refs is objects targeted by Enable, Disable, and GetDisabled
-            foreach (Papyrus.Call call in allCalls)
-            {
-                // Grab record reference from target if exists
-                if (call.target != null && call.target != "player")
-                {
-                    if (!allReferences.Contains(call.target)) { allReferences.Add(call.target); }
-
-                    switch (call.type)
-                    {
-                        case Papyrus.Call.Type.Enable:
-                        case Papyrus.Call.Type.Disable:
-                        case Papyrus.Call.Type.GetDisabled:
-                            if (!ableReferences.Contains(call.target)) { ableReferences.Add(call.target); }
-                            break;
-                        default: break;
-                    }
-                }
-
-                // Grab record reference from arguments if they exist
-                switch (call.type)
-                {
-                    case Papyrus.Call.Type.Cast:
-                        {
-                            string reference = call.parameters[1].ToLower().Trim();
-                            if (reference == "player") { break; }
-                            allReferences.Add(reference);
-                            break;
-                        }
-                    case Papyrus.Call.Type.GetDistance:
-                        {
-                            string reference = call.parameters[0].ToLower().Trim();
-                            if (reference == "player") { break; }
-                            allReferences.Add(reference);
-                            break;
-                        }
-                    default: break;
-                }
-            }
-
-            void PreProcessSelfDisableCalls(Cell cell)
-            {
-                foreach (Content content in cell.contents)
-                {
-                    Papyrus papyrus = esm.GetPapyrus(content.papyrus);
-                    if (
-                        papyrus != null &&
-                        (
-                            papyrus.HasCall(Papyrus.Call.Type.Disable) ||
-                            papyrus.HasCall(Papyrus.Call.Type.Enable) ||
-                            papyrus.HasCall(Papyrus.Call.Type.GetDisabled)
-                        )
-                    )
-                    {
-                        string contentId = content.id.ToLower().Trim();
-                        if (!ableReferences.Contains(contentId)) { ableReferences.Add(contentId); }
-                    }
-                }
-            }
-
-            foreach (Cell cell in esm.exterior) { PreProcessSelfDisableCalls(cell); }
-            foreach (Cell cell in esm.interior) { PreProcessSelfDisableCalls(cell); }
+            // able refs is objects targeted by Enable, Disable, and GetDisabled
+            var (allReferences, toggleableReferences) = esm.GetScriptReferences();
             Lort.TaskIterate(); // Progress bar update
 
             /* Subdivide all cell content into tiles */
@@ -514,7 +442,7 @@ namespace JortPob
                         content.entity = areaScript.CreateEntity(entityType, $"{content.type}::{content.id}");
 
                         // talkable characters always get disable flags for simplicity. statically resolving dialog triggered self-disable calls is slow as hell
-                        if (content is NpcContent || (content is CreatureContent && esm.HasDialog((CreatureContent)content)) || ableReferences.Contains(contentId))
+                        if (content is NpcContent || (content is CreatureContent && esm.HasDialog((CreatureContent)content)) || toggleableReferences.Contains(contentId))
                         {
                             // Object disabled flag
                             Script.Flag disableFlag = areaScript.CreateFlag(Script.Flag.Category.Saved, Script.Flag.Type.Bit, Script.Flag.Designation.Disabled, content);

--- a/JortPob/Layout.cs
+++ b/JortPob/Layout.cs
@@ -24,7 +24,7 @@ namespace JortPob
         private readonly List<InteriorGroup> interiors = [];
 
         // For now, we just expose IEnumerable in case we need to change the underlying implementation
-        public IEnumerable<BaseTile> AllTiles => [tiles, bigs, huges];
+        public IEnumerable<BaseTile> AllTiles => new IEnumerable<BaseTile>[]{tiles, bigs, huges}.SelectMany(t => t);
 
         public IEnumerable<Tile> Tiles => tiles;
         public int TileCount => tiles.Count;

--- a/JortPob/Layout.cs
+++ b/JortPob/Layout.cs
@@ -24,7 +24,7 @@ namespace JortPob
         private readonly List<InteriorGroup> interiors = [];
 
         // For now, we just expose IEnumerable in case we need to change the underlying implementation
-        public IEnumerable<BaseTile> AllTiles => new IEnumerable<BaseTile>[]{tiles, bigs, huges}.SelectMany(t => t);
+        public IEnumerable<BaseTile> AllTiles => [tiles, bigs, huges];
 
         public IEnumerable<Tile> Tiles => tiles;
         public int TileCount => tiles.Count;

--- a/JortPob/Layout.cs
+++ b/JortPob/Layout.cs
@@ -38,10 +38,13 @@ namespace JortPob
             Lort.NewTask("Generating Layout", 14);
 
             /* Generate tiles based off base game msb info... */
-            string msbdata = File.ReadAllText(Utility.ResourcePath(@"msb\msblist.txt"));
-            string[][] msblist = msbdata.Split(";").Select(msb => msb.Split(",")).ToArray();
+            var msbData = ProcessMsbList(
+                File.ReadAllText(Utility.ResourcePath(@"msb\msblist.txt"))
+                        .Split(";")
+                        .Select(msb => msb.Split(","))
+            ).ToList();
 
-            tiles = ProcessMsbList(msblist)
+            tiles = msbData
                 .Where(t => t.b == 0 && t.m == MapId)
                 .Select(t => new Tile(t.m, t.x, t.y, t.b))
                 .ToList();
@@ -49,7 +52,7 @@ namespace JortPob
             Lort.TaskIterate(); // Progress bar update
             
             /* Generate BigTiles... */
-            foreach (var (m, x, y, b) in ProcessMsbList(msblist))
+            foreach (var (m, x, y, b) in msbData)
             {
                 if (m != MapId || b != 1) continue;
                 BigTile big = new(m, x, y, b);
@@ -59,7 +62,7 @@ namespace JortPob
             Lort.TaskIterate(); // Progress bar update
 
             /* Generate HugeTiles... */
-            foreach (var (m, x, y, b) in ProcessMsbList(msblist))
+            foreach (var (m, x, y, b) in msbData)
             {
                 if (m != MapId || b != 2) continue;
                 HugeTile huge = new(m, x, y, b);
@@ -72,7 +75,7 @@ namespace JortPob
             /* Generate Interior Groups */
             HashSet<int> validMaps =
                 [12, 13, 14, 15, 16, 19, 20, 21, 22, 25, 28, 30, 31, 32, 34, 35, 39, 40, 41, 42, 43];
-            interiors = ProcessMsbList(msblist)
+            interiors = msbData
                 .Where(t => t is { y: 0, b: 0 } && validMaps.Contains(t.m))
                 .Select(t => {
                     var (m, a, u, b) = t;
@@ -1149,7 +1152,7 @@ namespace JortPob
             return result;
         }
 
-        private static IEnumerable<(int m, int x, int y, int b)> ProcessMsbList(string[][] msblist)
+        private static IEnumerable<(int m, int x, int y, int b)> ProcessMsbList(IEnumerable<string[]> msblist)
         {
             foreach (var split in msblist)
             {

--- a/JortPob/Layout.cs
+++ b/JortPob/Layout.cs
@@ -24,7 +24,7 @@ namespace JortPob
         private readonly List<InteriorGroup> interiors = [];
 
         // For now, we just expose IEnumerable in case we need to change the underlying implementation
-        public IEnumerable<BaseTile> AllTiles => new IEnumerable<BaseTile>[]{tiles, bigs, huges}.SelectMany(t => t);
+        public IEnumerable<BaseTile> AllTiles => [..tiles, ..bigs, ..huges];
 
         public IEnumerable<Tile> Tiles => tiles;
         public int TileCount => tiles.Count;

--- a/JortPob/Main.cs
+++ b/JortPob/Main.cs
@@ -60,10 +60,10 @@ namespace JortPob
             /* Generate exterior msbs from layout */
             List<ResourcePool> msbs = new();
             
-            Lort.Log($"Generating {layout.tiles.Count} exterior msbs...", Lort.Type.Main);
-            Lort.NewTask("Generating MSB", layout.tiles.Count);
+            Lort.Log($"Generating {layout.TileCount} exterior msbs...", Lort.Type.Main);
+            Lort.NewTask("Generating MSB", layout.TileCount);
 
-            foreach (BaseTile tile in layout.all)
+            foreach (BaseTile tile in layout.AllTiles)
             {
                 // Just write empty tiles as empty msbs and scripts to prevent base game stuff from loading in the distance. Debug flag if you want to skip this behaviour
                 if (tile.IsEmpty() && Const.DEBUG_DONT_WRITE_BLANK_MSBS) { continue; }
@@ -552,9 +552,9 @@ namespace JortPob
             }
 
             /* Generate interior msbs from interiorgroups */
-            Lort.Log($"Generating {layout.interiors.Count} interior msbs...", Lort.Type.Main);
-            Lort.NewTask("Generating MSB", layout.interiors.Count);
-            foreach (InteriorGroup group in layout.interiors)
+            Lort.Log($"Generating {layout.InteriorCount} interior msbs...", Lort.Type.Main);
+            Lort.NewTask("Generating MSB", layout.InteriorCount);
+            foreach (InteriorGroup group in layout.Interiors)
             {
                 // Skip empty groups.
                 if (group.IsEmpty()) { continue; }
@@ -1053,14 +1053,14 @@ namespace JortPob
             if (!Const.DEBUG_SKIP_NAVMESH)
             {
                 List<string> objs = new();
-                foreach (BaseTile bt in layout.tiles)
+                foreach (BaseTile bt in layout.Tiles)
                 {
                     if (bt is not Tile tile || tile.IsEmpty()) { continue; } // skip big/huge tiles and empty tiles
                     string objPath = Path.Combine(Const.CACHE_PATH, $@"nav\m{tile.map:D2}_{tile.coordinate.x:D2}_{tile.coordinate.y:D2}_{tile.block:D2}.obj");
                     tile.nav.collapse(Obj.CollisionMaterial.Stock).optimize().write(objPath);
                     objs.Add(objPath);
                 }
-                foreach (InteriorGroup group in layout.interiors)
+                foreach (InteriorGroup group in layout.Interiors)
                 {
                     if (group.IsEmpty()) { continue; } // skip empty groups
 
@@ -1076,9 +1076,9 @@ namespace JortPob
                 NavWorker.Go(objs);
 
                 /* After all the nav conversions are finshed we can now do nvas and nvbnds */
-                Lort.Log($"Binding {layout.tiles.Count() + layout.interiors.Count()} NVBNDs...", Lort.Type.Main);
-                Lort.NewTask("Binding NVBNDs", layout.tiles.Count() + layout.interiors.Count());
-                foreach (BaseTile bt in layout.tiles)
+                Lort.Log($"Binding {layout.TileCount + layout.InteriorCount} NVBNDs...", Lort.Type.Main);
+                Lort.NewTask("Binding NVBNDs", layout.TileCount + layout.InteriorCount);
+                foreach (BaseTile bt in layout.Tiles)
                 {
                     if (bt is not Tile tile || tile.IsEmpty()) { continue; } // skip big/huge tiles
 
@@ -1138,7 +1138,7 @@ namespace JortPob
                     nvbnd.Write(Path.Combine(Const.OUTPUT_PATH, "map", $"m{tile.map:D2}", $"m{mid}", $"m{mid}.nvmhktbnd.dcx"));
                     Lort.TaskIterate();
                 }
-                foreach (InteriorGroup group in layout.interiors)
+                foreach (InteriorGroup group in layout.Interiors)
                 {
                     /* Some vars */
                     int bid = 10000;

--- a/JortPob/Paramanager.cs
+++ b/JortPob/Paramanager.cs
@@ -674,7 +674,7 @@ namespace JortPob
             FsParam mapRegionParam = param[ParamType.MapGdRegionInfoParam];
 
             // Exterior msbs
-            foreach (Tile tile in layout.tiles)
+            foreach (Tile tile in layout.Tiles)
             {
                 if (tile.IsEmpty()) { continue; } // skip empty tiles
 
@@ -697,7 +697,7 @@ namespace JortPob
             }
 
             // Interior msbs
-            foreach (InteriorGroup group in layout.interiors)
+            foreach (InteriorGroup group in layout.Interiors)
             {
                 if (group.IsEmpty()) { continue; } // skip empty group
 

--- a/JortPob/Test.cs
+++ b/JortPob/Test.cs
@@ -140,7 +140,7 @@ namespace JortPob
 
 
             List<ResourcePool> pools = new();
-            foreach (BaseTile tile in layout.all)
+            foreach (BaseTile tile in layout.AllTiles)
             {
                 if (tile.assets.Count <= 0 && tile.terrain.Count <= 0) { continue; }   // Skip empty tiles.
 

--- a/JortPob/Tile.cs
+++ b/JortPob/Tile.cs
@@ -316,5 +316,23 @@ namespace JortPob
                     Lort.Log($" ## WARNING ## Unhandled Content class '{content.type}::{content.id}' fell through AddContent()", Lort.Type.Debug); break;
             }
         }
+        
+        /**
+         * We double the coordinates from our center to approximate the tile shape, then check each of
+         * the `tilesToAdd` to see if it is entirely contained within the BigTile (with a little padding),
+         * and add any that are fully contained.
+         *
+         * This is mainly useful in `BigTile`/`HugeTile`, but our class hierarchy puts the implementation here.
+         */
+        protected IEnumerable<T> FilterTilesToAdd<T>(IEnumerable<T> tilesToAdd, int scaleFactor, int padding) where T: BaseTile
+        {
+            var x1 = coordinate.x * scaleFactor;
+            var y1 = coordinate.y * scaleFactor;
+            var x2 = x1 + padding;
+            var y2 = y1 + padding;
+
+            return tilesToAdd.Where(t =>
+                t.coordinate.x >= x1 && t.coordinate.x < x2 && t.coordinate.y >= y1 && t.coordinate.y < y2);
+        }
     }
 }


### PR DESCRIPTION
This PR refactors various aspects of the `Layout` constructor to slim it down and improve performance/readability. The theme of a lot of these changes to to reduce how much we reach into the internals of other classes, such as assigning property values deeply within warps.

### Notable Changes

- Moving the big/huge tile handling into their respective classes
- Add methods for applying new door/NPC warp params
- Move script reference calculation into new ESM `GetScriptReferences` method
- Hides the tile/interior fields behind getters that expose `IEnumerable` to make future refactors easier if we end up map-ifying them