### PR TITLE
Spell-as-item: AddSpell/RemoveSpell now grant reusable scroll items

### DIFF
--- a/JortPob/ESM/Dialog.cs
+++ b/JortPob/ESM/Dialog.cs
@@ -1136,11 +1136,15 @@ namespace JortPob
                         case Papyrus.Call.Type.RemoveSpell:
                             {
                                 SpeffManager.SpeffSpell spell = speffManager.GetSpellSpeff(call.parameters[0]);
+                                if (spell == null) { Lort.Log($"RemoveSpell: no SpeffSpell for '{call.parameters[0]}', skipping", Lort.Type.Debug); break; }
                                 if (call.target == "player")
                                 {
                                     if (spell.spellType == SpeffManager.SpeffSpell.SpellType.Spell || spell.spellType == SpeffManager.SpeffSpell.SpellType.Power)
                                     {
-                                        // @TODO: stub. this should remove a spell item from a players inventory but we dont have those mapped out yet
+                                        ItemManager.ItemInfo scroll = itemManager.GetSpellScroll(call.parameters[0]);
+                                        if (scroll == null) { Lort.Log($"RemoveSpell: no scroll registered for '{call.parameters[0]}', skipping", Lort.Type.Debug); break; }
+                                        Script.Flag removeFlag = scriptManager.common.GetOrRegisterRemoveItem(scroll, 1);
+                                        lines.Add($"SetEventFlag({removeFlag.id}, FlagState.On)");
                                     }
                                     else
                                     {

--- a/JortPob/ESM/Dialog.cs
+++ b/JortPob/ESM/Dialog.cs
@@ -1156,6 +1156,7 @@ namespace JortPob
                         case Papyrus.Call.Type.Cast:
                             {
                                 SpeffManager.SpeffSpell spell = speffManager.GetSpellSpeff(call.parameters[0]);
+                                if (spell == null) { Lort.Log($"Cast: no SpeffSpell for '{call.parameters[0]}', skipping", Lort.Type.Debug); break; }
                                 if (call.parameters[1].ToLower().Trim() == "player")
                                 {
                                     if (spell.spellType == SpeffManager.SpeffSpell.SpellType.Spell || spell.spellType == SpeffManager.SpeffSpell.SpellType.Power)

--- a/JortPob/ESM/Dialog.cs
+++ b/JortPob/ESM/Dialog.cs
@@ -1116,11 +1116,15 @@ namespace JortPob
                         case Papyrus.Call.Type.AddSpell:
                             {
                                 SpeffManager.SpeffSpell spell = speffManager.GetSpellSpeff(call.parameters[0]);
+                                if (spell == null) { Lort.Log($"AddSpell: no SpeffSpell for '{call.parameters[0]}', skipping", Lort.Type.Debug); break; }
                                 if (call.target == "player")
                                 {
                                     if (spell.spellType == SpeffManager.SpeffSpell.SpellType.Spell || spell.spellType == SpeffManager.SpeffSpell.SpellType.Power)
                                     {
-                                        // @TODO: stub. should give the player the item of a spell. we don't really have those all mapped out yet though so guh
+                                        ItemManager.ItemInfo scroll = itemManager.GetSpellScroll(call.parameters[0]);
+                                        if (scroll == null) { Lort.Log($"AddSpell: no scroll registered for '{call.parameters[0]}', skipping", Lort.Type.Debug); break; }
+                                        int row = paramanager.GenerateAddItemLot(scroll, 1);
+                                        lines.Add($"AwardItemLot({row})");
                                     }
                                     else
                                     {

--- a/JortPob/ItemManager.cs
+++ b/JortPob/ItemManager.cs
@@ -397,6 +397,9 @@ namespace JortPob
 
             /* Okay I lied, for real lastly we create recipemanager which handles alchemy recipe stuff */
             recipeManager = new RecipeManager(paramanager, scriptManager, this, textManager);
+
+            /* Generate Goods item ("scroll") per Spell/Power so AddSpell/RemoveSpell can grant/remove them. */
+            RegisterSpellScrolls();
         }
 
         /* Generates one reusable Goods item per Morrowind Spell/Power, linked to the SpEffect SpeffManager already produces.

--- a/JortPob/ItemManager.cs
+++ b/JortPob/ItemManager.cs
@@ -399,6 +399,98 @@ namespace JortPob
             recipeManager = new RecipeManager(paramanager, scriptManager, this, textManager);
         }
 
+        /* Generates one reusable Goods item per Morrowind Spell/Power, linked to the SpEffect SpeffManager already produces.
+         * The scroll's refId_default fires the existing SpEffect on use; isConsume=0 keeps it in inventory.
+         * maxRepositoryNum=1 caps the inventory at one per spell so duplicate AddSpell calls silently no-op. */
+        private void RegisterSpellScrolls()
+        {
+            // The set of MagicEffect cases that SpeffManager.GenerateSpeff actually maps onto SpEffect fields.
+            // If a spell has no effect from this set, the resulting scroll is inert; we mark it [unimplemented]
+            // in the description so the punch-list of unmapped effects is visible from an FMG dump.
+            HashSet<SpeffManager.Speff.Effect.MagicEffect> mapped = new()
+            {
+                SpeffManager.Speff.Effect.MagicEffect.RestoreHealth,
+                SpeffManager.Speff.Effect.MagicEffect.RestoreMagicka,
+                SpeffManager.Speff.Effect.MagicEffect.RestoreFatigue,
+                SpeffManager.Speff.Effect.MagicEffect.FortifyHealth,
+                SpeffManager.Speff.Effect.MagicEffect.FortifyMagicka,
+                SpeffManager.Speff.Effect.MagicEffect.FortifyFatigue,
+                SpeffManager.Speff.Effect.MagicEffect.FortifyAttribute,
+            };
+
+            FsParam goodsParam = paramanager.param[Paramanager.ParamType.EquipParamGoods];
+
+            List<SpeffManager.SpeffSpell> spells = new();
+            spells.AddRange(speffManager.GetSpeffBySpellType(SpeffManager.SpeffSpell.SpellType.Spell));
+            spells.AddRange(speffManager.GetSpeffBySpellType(SpeffManager.SpeffSpell.SpellType.Power));
+
+            foreach (SpeffManager.SpeffSpell spell in spells)
+            {
+                // Clone Divine Blessing (2000900) as the goods template — already used as a goods template
+                // elsewhere in this file. Meaningful fields are overridden below.
+                FsParam.Row row = paramanager.CloneRow(goodsParam[2000900], $"Scroll :: {spell.id}", nextGoodsId);
+
+                row["refId_default"].Value.SetValue(spell.row);              // fire the existing SpEffect on use
+                row["isConsume"].Value.SetValue((byte)0);                    // reusable
+                row["maxNum"].Value.SetValue((short)1);                      // cap inventory at one
+                row["maxRepositoryNum"].Value.SetValue((short)1);            // cap repository at one too
+
+                // Icon: pull from the same buff-icon system SpeffManager already uses (SpeffManager.cs:205).
+                if (spell.effects.Count > 0)
+                {
+                    IconManager.BuffInfo buff = textureManager.icon.GetBuffByType(spell.effects[0].effect);
+                    if (buff != null) { row["iconId"].Value.SetValue((int)buff.id); }
+                    else { row["iconId"].Value.SetValue(-1); }
+                }
+                else
+                {
+                    row["iconId"].Value.SetValue(-1);
+                }
+
+                paramanager.AddOrReplaceRow(goodsParam, row);
+
+                // FMG text. Title-case the spell id for display ("fire_bite" -> "Fire Bite").
+                string displayName = $"Scroll of {ToTitleCase(spell.id)}";
+                string description = BuildScrollDescription(spell, mapped);
+                textManager.AddGoods(nextGoodsId, displayName, "", description, "");
+
+                // Track in spellScrolls dictionary for AddSpell/RemoveSpell stubs to look up.
+                ItemInfo info = new(spell.id, Type.Goods, nextGoodsId, 0, true, ItemInfo.OriginalType.MiscItem);
+                spellScrolls[spell.id] = info;
+                items.Add(info);
+
+                nextGoodsId += 10;
+            }
+        }
+
+        /* Title-cases a snake_case Morrowind id for display. "fire_bite" -> "Fire Bite". */
+        private static string ToTitleCase(string id)
+        {
+            string spaced = id.Replace('_', ' ').Trim();
+            return System.Globalization.CultureInfo.InvariantCulture.TextInfo.ToTitleCase(spaced);
+        }
+
+        /* Builds a description from the spell's effect list. Suffixes [unimplemented]
+         * if NO effect on the spell maps to a SpEffect field SpeffManager actually translates. */
+        private static string BuildScrollDescription(
+            SpeffManager.SpeffSpell spell,
+            HashSet<SpeffManager.Speff.Effect.MagicEffect> mapped)
+        {
+            if (spell.effects.Count == 0) { return "[unimplemented]"; }
+
+            System.Text.StringBuilder sb = new();
+            bool anyMapped = false;
+            foreach (SpeffManager.Speff.Effect e in spell.effects)
+            {
+                if (mapped.Contains(e.effect)) { anyMapped = true; }
+                if (sb.Length > 0) { sb.Append(", "); }
+                sb.Append(e.effect.ToString());
+                if (e.duration > 0) { sb.Append($" {e.duration}s"); }
+            }
+            if (!anyMapped) { sb.Append(" [unimplemented]"); }
+            return sb.ToString();
+        }
+
         private int GenerateCustomWeapon(Override.ItemRemap remap)
         {
             FsParam customWeaponParam = paramanager.param[Paramanager.ParamType.EquipParamCustomWeapon];

--- a/JortPob/ItemManager.cs
+++ b/JortPob/ItemManager.cs
@@ -40,6 +40,7 @@ namespace JortPob
 
         public readonly List<ItemInfo> items; // string is record if of item from MW. int is the row id of the item in Elden Ring, type is type of item in ER
         public readonly List<LeveledList> lists; // leveled lists for items
+        private readonly Dictionary<string, ItemInfo> spellScrolls = new(); // spell id -> generated scroll item, populated by RegisterSpellScrolls()
 
         private Paramanager paramanager;
         private ScriptManager scriptManager;
@@ -878,6 +879,13 @@ namespace JortPob
 
             /* No match! */
             return null;
+        }
+
+        /* Returns the scroll ItemInfo for a given Morrowind Spell or Power id, or null if no scroll exists. */
+        public ItemInfo GetSpellScroll(string spellId)
+        {
+            if (spellId == null) { return null; }
+            return spellScrolls.TryGetValue(spellId.Trim().ToLower(), out ItemInfo info) ? info : null;
         }
 
         /* Resolves a content objects inventory (record id and quanity) to actual ItemInfo objects */

--- a/JortPob/PapyrusEMEVD.cs
+++ b/JortPob/PapyrusEMEVD.cs
@@ -980,11 +980,15 @@ namespace JortPob
                     case Call.Type.AddSpell:
                         {
                             SpeffManager.SpeffSpell spell = speffManager.GetSpellSpeff(call.parameters[0]);
+                            if (spell == null) { Lort.Log($"AddSpell: no SpeffSpell for '{call.parameters[0]}', skipping", Lort.Type.Debug); break; }
                             if (call.target == "player")
                             {
                                 if (spell.spellType == SpeffManager.SpeffSpell.SpellType.Spell || spell.spellType == SpeffManager.SpeffSpell.SpellType.Power)
                                 {
-                                    // @TODO: stub. should give the player the item of a spell. we don't really have those all mapped out yet though so guh
+                                    ItemManager.ItemInfo scroll = itemManager.GetSpellScroll(call.parameters[0]);
+                                    if (scroll == null) { Lort.Log($"AddSpell: no scroll registered for '{call.parameters[0]}', skipping", Lort.Type.Debug); break; }
+                                    int row = paramanager.GenerateAddItemLot(scroll, 1);
+                                    lines.Add($"AwardItemLot({row});");
                                 }
                                 else
                                 {
@@ -997,11 +1001,15 @@ namespace JortPob
                     case Call.Type.RemoveSpell:
                         {
                             SpeffManager.SpeffSpell spell = speffManager.GetSpellSpeff(call.parameters[0]);
+                            if (spell == null) { Lort.Log($"RemoveSpell: no SpeffSpell for '{call.parameters[0]}', skipping", Lort.Type.Debug); break; }
                             if (call.target == "player")
                             {
                                 if (spell.spellType == SpeffManager.SpeffSpell.SpellType.Spell || spell.spellType == SpeffManager.SpeffSpell.SpellType.Power)
                                 {
-                                    // @TODO: stub. this should remove a spell item from a players inventory but we dont have those mapped out yet
+                                    ItemManager.ItemInfo scroll = itemManager.GetSpellScroll(call.parameters[0]);
+                                    if (scroll == null) { Lort.Log($"RemoveSpell: no scroll registered for '{call.parameters[0]}', skipping", Lort.Type.Debug); break; }
+                                    Script.Flag removeFlag = scriptManager.common.GetOrRegisterRemoveItem(scroll, 1);
+                                    lines.Add($"SetEventFlag(TargetEventFlagType.EventFlag, {removeFlag.id}, ON);");
                                 }
                                 else
                                 {
@@ -1021,6 +1029,7 @@ namespace JortPob
                     case Call.Type.Cast:
                         {
                             SpeffManager.SpeffSpell spell = speffManager.GetSpellSpeff(call.parameters[0]);
+                            if (spell == null) { Lort.Log($"Cast: no SpeffSpell for '{call.parameters[0]}', skipping", Lort.Type.Debug); break; }
                             if (call.parameters[1].ToLower().Trim() == "player")
                             {
                                 if (spell.spellType == SpeffManager.SpeffSpell.SpellType.Spell || spell.spellType == SpeffManager.SpeffSpell.SpellType.Power)

--- a/docs/superpowers/plans/2026-05-10-spell-as-item.md
+++ b/docs/superpowers/plans/2026-05-10-spell-as-item.md
@@ -1,0 +1,703 @@
+# Spell-as-Item Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Morrowind `AddSpell`/`RemoveSpell` calls produce reusable scroll items for Elden Ring, wired to the SpEffect rows that `SpeffManager` already generates.
+
+**Architecture:** Extend `ItemManager` with a `RegisterSpellScrolls()` pass that runs at the end of construction. For each Spell/Power SpeffSpell, clone Divine Blessing (`EquipParamGoods` row 2000900) as a template, override `refId_default = spell.row` to link the existing SpEffect, set `isConsume = 0` for reusable behavior, allocate a row id from the existing `nextGoodsId` counter, and add an entry to a new `spellScrolls` dictionary keyed by spell id. Replace the AddSpell/RemoveSpell stubs in `Dialog.cs` and `PapyrusEMEVD.cs` with calls that route through the existing `AwardItemLot` / `GetOrRegisterRemoveItem` flows the working AddItem/RemoveItem paths already use. Add null-spell guards to the AddSpell, RemoveSpell, and Cast branches (latent bug — `Dialog.cs:1118` etc. dereference without checking).
+
+**Tech Stack:** C# / .NET 8, MSTest (`JortPob.Tests`), SoulsFormats `EquipParamGoods` param, FMG text banks via `TextManager`, IronPython compiler embedded for ESDLang.
+
+**Spec:** [`docs/superpowers/specs/2026-05-10-spell-as-item-design.md`](../specs/2026-05-10-spell-as-item-design.md)
+
+---
+
+## File map
+
+| File | Change | Reason |
+|---|---|---|
+| `JortPob/ItemManager.cs` | Modify | Add `spellScrolls` dict, `RegisterSpellScrolls()` method, `GetSpellScroll()` accessor; call from constructor |
+| `JortPob/ESM/Dialog.cs` | Modify (lines 1116–1158) | Replace AddSpell + RemoveSpell stubs; add null guard to Cast |
+| `JortPob/PapyrusEMEVD.cs` | Modify (lines 980–1033) | Mirror of Dialog.cs changes for EMEVD path |
+
+No new files. No new managers. `Main.cs` is **not** modified — `ItemManager` already takes `SpeffManager` as its 4th constructor arg.
+
+---
+
+## Task 1: Add `spellScrolls` dict + `GetSpellScroll` accessor (empty stubs)
+
+**Files:**
+- Modify: `JortPob/ItemManager.cs` (around line 41-50, the field block)
+
+- [ ] **Step 1.1: Add the field and accessor**
+
+In `JortPob/ItemManager.cs`, immediately after the existing `items` and `lists` fields (currently at line 41-42):
+
+```csharp
+public readonly List<ItemInfo> items; // string is record if of item from MW. int is the row id of the item in Elden Ring, type is type of item in ER
+public readonly List<LeveledList> lists; // leveled lists for items
+private readonly Dictionary<string, ItemInfo> spellScrolls = new(); // spell id -> generated scroll item, populated by RegisterSpellScrolls()
+```
+
+Then add a public accessor near the existing `GetItem` method (currently at line 865). Find `public ItemInfo GetItem(string id)` and add immediately above or below it:
+
+```csharp
+/* Returns the scroll ItemInfo for a given Morrowind Spell or Power id, or null if no scroll exists. */
+public ItemInfo GetSpellScroll(string spellId)
+{
+    if (spellId == null) { return null; }
+    return spellScrolls.TryGetValue(spellId.Trim().ToLower(), out ItemInfo info) ? info : null;
+}
+```
+
+- [ ] **Step 1.2: Build to confirm compile**
+
+Run: `dotnet build C:\Users\erica\source\repos\JortPob\JortPob.sln`
+Expected: Build succeeded, no warnings about the new code.
+
+- [ ] **Step 1.3: Commit**
+
+```powershell
+git add JortPob/ItemManager.cs
+git commit -m "Add empty spellScrolls dict and GetSpellScroll accessor on ItemManager"
+```
+
+---
+
+## Task 2: Implement `RegisterSpellScrolls` (not yet called)
+
+**Files:**
+- Modify: `JortPob/ItemManager.cs` (add a new private method, do not call it yet)
+
+- [ ] **Step 2.1: Add the method**
+
+Add the following private method to `ItemManager` (place it near the constructor, after the existing initialization helpers):
+
+```csharp
+/* Generates one reusable Goods item per Morrowind Spell/Power, linked to the SpEffect SpeffManager already produces.
+ * The scroll's refId_default fires the existing SpEffect on use; isConsume=0 keeps it in inventory.
+ * maxRepositoryNum=1 caps the inventory at one per spell so duplicate AddSpell calls silently no-op. */
+private void RegisterSpellScrolls()
+{
+    // The set of MagicEffect cases that SpeffManager.GenerateSpeff actually maps onto SpEffect fields.
+    // If a spell has no effect from this set, the resulting scroll is inert; we mark it [unimplemented]
+    // in the description so the punch-list of unmapped effects is visible from an FMG dump.
+    HashSet<SpeffManager.Speff.Effect.MagicEffect> mapped = new()
+    {
+        SpeffManager.Speff.Effect.MagicEffect.RestoreHealth,
+        SpeffManager.Speff.Effect.MagicEffect.RestoreMagicka,
+        SpeffManager.Speff.Effect.MagicEffect.RestoreFatigue,
+        SpeffManager.Speff.Effect.MagicEffect.FortifyHealth,
+        SpeffManager.Speff.Effect.MagicEffect.FortifyMagicka,
+        SpeffManager.Speff.Effect.MagicEffect.FortifyFatigue,
+        SpeffManager.Speff.Effect.MagicEffect.FortifyAttribute,
+    };
+
+    FsParam goodsParam = paramanager.param[Paramanager.ParamType.EquipParamGoods];
+
+    List<SpeffManager.SpeffSpell> spells = new();
+    spells.AddRange(speffManager.GetSpeffBySpellType(SpeffManager.SpeffSpell.SpellType.Spell));
+    spells.AddRange(speffManager.GetSpeffBySpellType(SpeffManager.SpeffSpell.SpellType.Power));
+
+    foreach (SpeffManager.SpeffSpell spell in spells)
+    {
+        // Clone Divine Blessing (2000900) as the goods template — already used as a goods template
+        // elsewhere in this file. Meaningful fields are overridden below.
+        FsParam.Row row = paramanager.CloneRow(goodsParam[2000900], $"Scroll :: {spell.id}", nextGoodsId);
+
+        row["refId_default"].Value.SetValue(spell.row);              // fire the existing SpEffect on use
+        row["isConsume"].Value.SetValue((byte)0);                    // reusable
+        row["maxNum"].Value.SetValue((short)1);                      // cap inventory at one
+        row["maxRepositoryNum"].Value.SetValue((short)1);            // cap repository at one too
+
+        // Icon: pull from the same buff-icon system SpeffManager already uses (SpeffManager.cs:205).
+        if (spell.effects.Count > 0)
+        {
+            IconManager.BuffInfo buff = textureManager.icon.GetBuffByType(spell.effects[0].effect);
+            if (buff != null) { row["iconId"].Value.SetValue((int)buff.id); }
+            else { row["iconId"].Value.SetValue(-1); }
+        }
+        else
+        {
+            row["iconId"].Value.SetValue(-1);
+        }
+
+        paramanager.AddOrReplaceRow(goodsParam, row);
+
+        // FMG text. Title-case the spell id for display ("fire_bite" -> "Fire Bite").
+        string displayName = $"Scroll of {ToTitleCase(spell.id)}";
+        string description = BuildScrollDescription(spell, mapped);
+        textManager.AddGoods(nextGoodsId, displayName, "", description, "");
+
+        // Track in spellScrolls dictionary for AddSpell/RemoveSpell stubs to look up.
+        ItemInfo info = new(spell.id, Type.Goods, nextGoodsId, 0, true, ItemInfo.OriginalType.MiscItem);
+        spellScrolls[spell.id] = info;
+        items.Add(info);
+
+        nextGoodsId += 10;
+    }
+}
+
+/* Title-cases a snake_case Morrowind id for display. "fire_bite" -> "Fire Bite". */
+private static string ToTitleCase(string id)
+{
+    string spaced = id.Replace('_', ' ').Trim();
+    return System.Globalization.CultureInfo.InvariantCulture.TextInfo.ToTitleCase(spaced);
+}
+
+/* Builds a description from the spell's effect list. Suffixes [unimplemented]
+ * if NO effect on the spell maps to a SpEffect field SpeffManager actually translates. */
+private static string BuildScrollDescription(
+    SpeffManager.SpeffSpell spell,
+    HashSet<SpeffManager.Speff.Effect.MagicEffect> mapped)
+{
+    if (spell.effects.Count == 0) { return "[unimplemented]"; }
+
+    System.Text.StringBuilder sb = new();
+    bool anyMapped = false;
+    foreach (SpeffManager.Speff.Effect e in spell.effects)
+    {
+        if (mapped.Contains(e.effect)) { anyMapped = true; }
+        if (sb.Length > 0) { sb.Append(", "); }
+        sb.Append(e.effect.ToString());
+        if (e.duration > 0) { sb.Append($" {e.duration}s"); }
+    }
+    if (!anyMapped) { sb.Append(" [unimplemented]"); }
+    return sb.ToString();
+}
+```
+
+- [ ] **Step 2.2: Build to confirm compile**
+
+Run: `dotnet build C:\Users\erica\source\repos\JortPob\JortPob.sln`
+Expected: Build succeeded.
+
+If compile fails on `ItemInfo.OriginalType.MiscItem`, verify by searching: `Grep "MiscItem" JortPob/ItemManager.cs`. If absent, substitute `ItemInfo.OriginalType.Apparatus` or another scalar from the OriginalType enum near `ItemManager.cs:1280-1292` — the field is informational only for spell scrolls.
+
+- [ ] **Step 2.3: Commit**
+
+```powershell
+git add JortPob/ItemManager.cs
+git commit -m "Implement RegisterSpellScrolls (not yet wired into ctor)"
+```
+
+---
+
+## Task 3: Wire `RegisterSpellScrolls` into the constructor
+
+**Files:**
+- Modify: `JortPob/ItemManager.cs` constructor end (around line 850 — find the closing `}` of the constructor)
+
+- [ ] **Step 3.1: Locate the constructor's closing brace**
+
+Run: `Grep -n "public ItemManager" JortPob/ItemManager.cs` — note the line number.
+Read 50 lines around the matching `}` for the closing brace of the constructor (the constructor starts at line 54; scroll forward in the file to find where it ends — should be near the top of the next public method).
+
+- [ ] **Step 3.2: Add the call as the last statement of the constructor**
+
+Immediately before the closing `}` of `public ItemManager(...)`, add:
+
+```csharp
+        /* Generate Goods item ("scroll") per Spell/Power so AddSpell/RemoveSpell can grant/remove them. */
+        RegisterSpellScrolls();
+    }
+```
+
+(The `}` is the existing closing brace — the new line goes on the line above it.)
+
+- [ ] **Step 3.3: Build**
+
+Run: `dotnet build C:\Users\erica\source\repos\JortPob\JortPob.sln`
+Expected: Build succeeded.
+
+- [ ] **Step 3.4: Run the test suite for regression**
+
+Run: `dotnet test C:\Users\erica\source\repos\JortPob\JortPob.sln`
+Expected: 1 test passing (the existing `LinearToSRGBShouldConvertCorrectly`), 0 failures.
+
+If failure: stop. Investigate. Do not proceed.
+
+- [ ] **Step 3.5: Commit**
+
+```powershell
+git add JortPob/ItemManager.cs
+git commit -m "Wire RegisterSpellScrolls into ItemManager ctor"
+```
+
+---
+
+## Task 4: Replace AddSpell stub in `Dialog.cs`
+
+**Files:**
+- Modify: `JortPob/ESM/Dialog.cs:1116-1131`
+
+- [ ] **Step 4.1: Read the current stub**
+
+Run: Read `JortPob/ESM/Dialog.cs` lines 1116-1131. Confirm it matches the block starting `case Papyrus.Call.Type.AddSpell:` and containing `// @TODO: stub. should give the player the item of a spell...`.
+
+- [ ] **Step 4.2: Replace the stub**
+
+Find the block:
+
+```csharp
+                        case Papyrus.Call.Type.AddSpell:
+                            {
+                                SpeffManager.SpeffSpell spell = speffManager.GetSpellSpeff(call.parameters[0]);
+                                if (call.target == "player")
+                                {
+                                    if (spell.spellType == SpeffManager.SpeffSpell.SpellType.Spell || spell.spellType == SpeffManager.SpeffSpell.SpellType.Power)
+                                    {
+                                        // @TODO: stub. should give the player the item of a spell. we don't really have those all mapped out yet though so guh
+                                    }
+                                    else
+                                    {
+                                        lines.Add($"SetEventFlag({spell.flag.id}, FlagState.On)");
+                                    }
+                                }
+                                break;
+                            }
+```
+
+Replace with:
+
+```csharp
+                        case Papyrus.Call.Type.AddSpell:
+                            {
+                                SpeffManager.SpeffSpell spell = speffManager.GetSpellSpeff(call.parameters[0]);
+                                if (spell == null) { Lort.Log($"AddSpell: no SpeffSpell for '{call.parameters[0]}', skipping", Lort.Type.Debug); break; }
+                                if (call.target == "player")
+                                {
+                                    if (spell.spellType == SpeffManager.SpeffSpell.SpellType.Spell || spell.spellType == SpeffManager.SpeffSpell.SpellType.Power)
+                                    {
+                                        ItemManager.ItemInfo scroll = itemManager.GetSpellScroll(call.parameters[0]);
+                                        if (scroll == null) { Lort.Log($"AddSpell: no scroll registered for '{call.parameters[0]}', skipping", Lort.Type.Debug); break; }
+                                        int row = paramanager.GenerateAddItemLot(scroll, 1);
+                                        lines.Add($"AwardItemLot({row})");
+                                    }
+                                    else
+                                    {
+                                        lines.Add($"SetEventFlag({spell.flag.id}, FlagState.On)");
+                                    }
+                                }
+                                break;
+                            }
+```
+
+- [ ] **Step 4.3: Build**
+
+Run: `dotnet build C:\Users\erica\source\repos\JortPob\JortPob.sln`
+Expected: Build succeeded.
+
+If `Lort.Type.Debug` is unrecognized, find a valid value with: `Grep -n "Lort.Log.*Lort.Type\." JortPob/ESM/Dialog.cs` — substitute one used elsewhere (likely `Lort.Type.Debug` or `Lort.Type.Main`).
+
+- [ ] **Step 4.4: Commit**
+
+```powershell
+git add JortPob/ESM/Dialog.cs
+git commit -m "Wire AddSpell stub in Dialog.cs to grant a scroll item"
+```
+
+---
+
+## Task 5: Replace RemoveSpell stub in `Dialog.cs`
+
+**Files:**
+- Modify: `JortPob/ESM/Dialog.cs:1132-1147`
+
+- [ ] **Step 5.1: Replace the block**
+
+Find:
+
+```csharp
+                        case Papyrus.Call.Type.RemoveSpell:
+                            {
+                                SpeffManager.SpeffSpell spell = speffManager.GetSpellSpeff(call.parameters[0]);
+                                if (call.target == "player")
+                                {
+                                    if (spell.spellType == SpeffManager.SpeffSpell.SpellType.Spell || spell.spellType == SpeffManager.SpeffSpell.SpellType.Power)
+                                    {
+                                        // @TODO: stub. this should remove a spell item from a players inventory but we dont have those mapped out yet
+                                    }
+                                    else
+                                    {
+                                        lines.Add($"SetEventFlag({spell.flag.id}, FlagState.Off)");
+                                    }
+                                }
+                                break;
+                            }
+```
+
+Replace with:
+
+```csharp
+                        case Papyrus.Call.Type.RemoveSpell:
+                            {
+                                SpeffManager.SpeffSpell spell = speffManager.GetSpellSpeff(call.parameters[0]);
+                                if (spell == null) { Lort.Log($"RemoveSpell: no SpeffSpell for '{call.parameters[0]}', skipping", Lort.Type.Debug); break; }
+                                if (call.target == "player")
+                                {
+                                    if (spell.spellType == SpeffManager.SpeffSpell.SpellType.Spell || spell.spellType == SpeffManager.SpeffSpell.SpellType.Power)
+                                    {
+                                        ItemManager.ItemInfo scroll = itemManager.GetSpellScroll(call.parameters[0]);
+                                        if (scroll == null) { Lort.Log($"RemoveSpell: no scroll registered for '{call.parameters[0]}', skipping", Lort.Type.Debug); break; }
+                                        Script.Flag removeFlag = scriptManager.common.GetOrRegisterRemoveItem(scroll, 1);
+                                        lines.Add($"SetEventFlag({removeFlag.id}, FlagState.On)");
+                                    }
+                                    else
+                                    {
+                                        lines.Add($"SetEventFlag({spell.flag.id}, FlagState.Off)");
+                                    }
+                                }
+                                break;
+                            }
+```
+
+- [ ] **Step 5.2: Build**
+
+Run: `dotnet build C:\Users\erica\source\repos\JortPob\JortPob.sln`
+Expected: Build succeeded.
+
+- [ ] **Step 5.3: Run tests**
+
+Run: `dotnet test C:\Users\erica\source\repos\JortPob\JortPob.sln`
+Expected: All passing.
+
+- [ ] **Step 5.4: Commit**
+
+```powershell
+git add JortPob/ESM/Dialog.cs
+git commit -m "Wire RemoveSpell stub in Dialog.cs to remove the scroll item"
+```
+
+---
+
+## Task 6: Add null-spell guard to Cast block in `Dialog.cs`
+
+**Files:**
+- Modify: `JortPob/ESM/Dialog.cs:1148-1158`
+
+- [ ] **Step 6.1: Replace the Cast block**
+
+Find:
+
+```csharp
+                        case Papyrus.Call.Type.Cast:
+                            {
+                                SpeffManager.SpeffSpell spell = speffManager.GetSpellSpeff(call.parameters[0]);
+                                if (call.parameters[1].ToLower().Trim() == "player")
+                                {
+                                    if (spell.spellType == SpeffManager.SpeffSpell.SpellType.Spell || spell.spellType == SpeffManager.SpeffSpell.SpellType.Power)
+                                    {
+                                        lines.Add($"GiveSpEffectToPlayer({spell.row})");
+                                    }
+                                }
+                                break;
+                            }
+```
+
+Replace with:
+
+```csharp
+                        case Papyrus.Call.Type.Cast:
+                            {
+                                SpeffManager.SpeffSpell spell = speffManager.GetSpellSpeff(call.parameters[0]);
+                                if (spell == null) { Lort.Log($"Cast: no SpeffSpell for '{call.parameters[0]}', skipping", Lort.Type.Debug); break; }
+                                if (call.parameters[1].ToLower().Trim() == "player")
+                                {
+                                    if (spell.spellType == SpeffManager.SpeffSpell.SpellType.Spell || spell.spellType == SpeffManager.SpeffSpell.SpellType.Power)
+                                    {
+                                        lines.Add($"GiveSpEffectToPlayer({spell.row})");
+                                    }
+                                }
+                                break;
+                            }
+```
+
+- [ ] **Step 6.2: Build**
+
+Run: `dotnet build C:\Users\erica\source\repos\JortPob\JortPob.sln`
+Expected: Build succeeded.
+
+- [ ] **Step 6.3: Commit**
+
+```powershell
+git add JortPob/ESM/Dialog.cs
+git commit -m "Guard Cast block against null SpeffSpell in Dialog.cs"
+```
+
+---
+
+## Task 7: Mirror the changes in `PapyrusEMEVD.cs`
+
+**Files:**
+- Modify: `JortPob/PapyrusEMEVD.cs:980-1033`
+
+The EMEVD path emits a different syntax than ESD (uses `;` terminators, `TargetEventFlagType.EventFlag, ON` instead of `FlagState.On`, etc.). Follow the **EMEVD-style** patterns exactly as they appear in the existing AddItem path at `PapyrusEMEVD.cs:1100-1122`.
+
+- [ ] **Step 7.1: Read the existing AddItem flow in PapyrusEMEVD**
+
+Read `JortPob/PapyrusEMEVD.cs:1080-1140` to confirm the AddItem and RemoveItem call patterns. The exact instruction names matter — copy them.
+
+- [ ] **Step 7.2: Replace the AddSpell case**
+
+Find the block at `PapyrusEMEVD.cs:980-995`:
+
+```csharp
+                    case Call.Type.AddSpell:
+                        {
+                            SpeffManager.SpeffSpell spell = speffManager.GetSpellSpeff(call.parameters[0]);
+                            if (call.target == "player")
+                            {
+                                if (spell.spellType == SpeffManager.SpeffSpell.SpellType.Spell || spell.spellType == SpeffManager.SpeffSpell.SpellType.Power)
+                                {
+                                    // @TODO: stub. should give the player the item of a spell. we don't really have those all mapped out yet though so guh
+                                }
+                                else
+                                {
+                                    lines.Add($"SetEventFlag(TargetEventFlagType.EventFlag, {spell.flag.id}, ON);");
+                                }
+                            }
+                            break;
+                        }
+```
+
+Replace with:
+
+```csharp
+                    case Call.Type.AddSpell:
+                        {
+                            SpeffManager.SpeffSpell spell = speffManager.GetSpellSpeff(call.parameters[0]);
+                            if (spell == null) { Lort.Log($"AddSpell: no SpeffSpell for '{call.parameters[0]}', skipping", Lort.Type.Debug); break; }
+                            if (call.target == "player")
+                            {
+                                if (spell.spellType == SpeffManager.SpeffSpell.SpellType.Spell || spell.spellType == SpeffManager.SpeffSpell.SpellType.Power)
+                                {
+                                    ItemManager.ItemInfo scroll = itemManager.GetSpellScroll(call.parameters[0]);
+                                    if (scroll == null) { Lort.Log($"AddSpell: no scroll registered for '{call.parameters[0]}', skipping", Lort.Type.Debug); break; }
+                                    int row = paramanager.GenerateAddItemLot(scroll, 1);
+                                    lines.Add($"AwardItemLot({row});");
+                                }
+                                else
+                                {
+                                    lines.Add($"SetEventFlag(TargetEventFlagType.EventFlag, {spell.flag.id}, ON);");
+                                }
+                            }
+                            break;
+                        }
+```
+
+- [ ] **Step 7.3: Replace the RemoveSpell case**
+
+Find the block at `PapyrusEMEVD.cs:997-1012`:
+
+```csharp
+                    case Call.Type.RemoveSpell:
+                        {
+                            SpeffManager.SpeffSpell spell = speffManager.GetSpellSpeff(call.parameters[0]);
+                            if (call.target == "player")
+                            {
+                                if (spell.spellType == SpeffManager.SpeffSpell.SpellType.Spell || spell.spellType == SpeffManager.SpeffSpell.SpellType.Power)
+                                {
+                                    // @TODO: stub. this should remove a spell item from a players inventory but we dont have those mapped out yet
+                                }
+                                else
+                                {
+                                    lines.Add($"SetEventFlag(TargetEventFlagType.EventFlag, {spell.flag.id}, OFF);");
+                                }
+                            }
+                            break;
+                        }
+```
+
+Replace with:
+
+```csharp
+                    case Call.Type.RemoveSpell:
+                        {
+                            SpeffManager.SpeffSpell spell = speffManager.GetSpellSpeff(call.parameters[0]);
+                            if (spell == null) { Lort.Log($"RemoveSpell: no SpeffSpell for '{call.parameters[0]}', skipping", Lort.Type.Debug); break; }
+                            if (call.target == "player")
+                            {
+                                if (spell.spellType == SpeffManager.SpeffSpell.SpellType.Spell || spell.spellType == SpeffManager.SpeffSpell.SpellType.Power)
+                                {
+                                    ItemManager.ItemInfo scroll = itemManager.GetSpellScroll(call.parameters[0]);
+                                    if (scroll == null) { Lort.Log($"RemoveSpell: no scroll registered for '{call.parameters[0]}', skipping", Lort.Type.Debug); break; }
+                                    Script.Flag removeFlag = scriptManager.common.GetOrRegisterRemoveItem(scroll, 1);
+                                    lines.Add($"SetEventFlag(TargetEventFlagType.EventFlag, {removeFlag.id}, ON);");
+                                }
+                                else
+                                {
+                                    lines.Add($"SetEventFlag(TargetEventFlagType.EventFlag, {spell.flag.id}, OFF);");
+                                }
+                            }
+                            break;
+                        }
+```
+
+- [ ] **Step 7.4: Add null guard to the Cast block in PapyrusEMEVD**
+
+Find the block at `PapyrusEMEVD.cs:1021-1033`:
+
+```csharp
+                    case Call.Type.Cast:
+                        {
+                            SpeffManager.SpeffSpell spell = speffManager.GetSpellSpeff(call.parameters[0]);
+                            if (call.parameters[1].ToLower().Trim() == "player")
+                            {
+                                if (spell.spellType == SpeffManager.SpeffSpell.SpellType.Spell || spell.spellType == SpeffManager.SpeffSpell.SpellType.Power)
+                                {
+                                    string code = $"SetSpEffect(10000, {spell.row});";
+                                    lines.Add(code);
+                                }
+                            }
+                            break;
+                        }
+```
+
+Replace with:
+
+```csharp
+                    case Call.Type.Cast:
+                        {
+                            SpeffManager.SpeffSpell spell = speffManager.GetSpellSpeff(call.parameters[0]);
+                            if (spell == null) { Lort.Log($"Cast: no SpeffSpell for '{call.parameters[0]}', skipping", Lort.Type.Debug); break; }
+                            if (call.parameters[1].ToLower().Trim() == "player")
+                            {
+                                if (spell.spellType == SpeffManager.SpeffSpell.SpellType.Spell || spell.spellType == SpeffManager.SpeffSpell.SpellType.Power)
+                                {
+                                    string code = $"SetSpEffect(10000, {spell.row});";
+                                    lines.Add(code);
+                                }
+                            }
+                            break;
+                        }
+```
+
+- [ ] **Step 7.5: Verify `itemManager` and `paramanager` are in scope**
+
+Run: `Grep -n "itemManager\|paramanager" JortPob/PapyrusEMEVD.cs` (head -10).
+Expected: both are passed into the surrounding method/class. If either is *not* in scope at the AddSpell/RemoveSpell sites, look at the existing AddItem case (`PapyrusEMEVD.cs:1100-1122`) for the same scope pattern — copy it. The AddItem case already uses both, so the names should be available.
+
+- [ ] **Step 7.6: Build**
+
+Run: `dotnet build C:\Users\erica\source\repos\JortPob\JortPob.sln`
+Expected: Build succeeded.
+
+- [ ] **Step 7.7: Run tests**
+
+Run: `dotnet test C:\Users\erica\source\repos\JortPob\JortPob.sln`
+Expected: All passing.
+
+- [ ] **Step 7.8: Commit**
+
+```powershell
+git add JortPob/PapyrusEMEVD.cs
+git commit -m "Wire AddSpell/RemoveSpell + Cast null-guard in PapyrusEMEVD.cs"
+```
+
+---
+
+## Task 8: Final regression test pass
+
+- [ ] **Step 8.1: Clean build**
+
+Run: `dotnet build C:\Users\erica\source\repos\JortPob\JortPob.sln --no-incremental`
+Expected: Build succeeded, 0 errors, 0 unexpected warnings (existing warnings are fine).
+
+- [ ] **Step 8.2: Test suite**
+
+Run: `dotnet test C:\Users\erica\source\repos\JortPob\JortPob.sln`
+Expected: 1 passing, 0 failed. Surface the output to the user.
+
+If failure: stop. Do not push. Investigate.
+
+---
+
+## Task 9: Manual full-build smoke verification
+
+This step requires running the actual JortPob converter against a real Morrowind install, which Claude cannot do automatically. **Surface this to the user as a manual checklist.**
+
+- [ ] **Step 9.1: Ask the user to run a full Convert**
+
+Tell the user:
+
+> "The branch is built and tests pass. Before I push, please run a full Convert through JortPob (your normal F5 / `dotnet run` workflow) and report:
+>
+> 1. Does Convert finish without exceptions?
+> 2. In a known AddSpell quest beat (Mages Guild starter, or any Restore-spell grant), does a 'Scroll of X' item appear in your inventory after triggering the dialog?
+> 3. Does using the scroll apply its effect (HP/MP/SP restore for mapped spells)?
+> 4. Does using the scroll keep it in inventory (reusable)?
+> 5. (Optional) Pick a damage spell granted by a script, verify the scroll appears with `[unimplemented]` in its description.
+>
+> Reply 'all good' or list any failures."
+
+- [ ] **Step 9.2: Wait for confirmation before proceeding to PR.**
+
+If the user reports failures, stop and address them — do NOT push the branch.
+
+---
+
+## Task 10: Push branch and open PR
+
+Only proceed after Task 9 confirms a clean smoke test.
+
+- [ ] **Step 10.1: Push the branch**
+
+```powershell
+git push -u origin spellAsItem
+```
+
+- [ ] **Step 10.2: Open the PR**
+
+```powershell
+gh pr create --title "Spell-as-item: AddSpell/RemoveSpell now grant reusable scroll items" --body "$(cat <<'EOF'
+## Summary
+- Replaces the AddSpell/RemoveSpell stubs in Dialog.cs and PapyrusEMEVD.cs so quest beats that grant or remove a Morrowind Spell or Power now produce a reusable scroll item in the player's inventory
+- Each spell scroll is wired to the SpEffect that SpeffManager already produces — using the scroll applies the SpEffect (heal, fortify, or inert for unmapped effects)
+- Spells whose effects are not yet mapped to SpEffect fields get a description suffix `[unimplemented]` so the inert scrolls form a self-documenting punch list of MagicEffect cases to map next
+- Adds null-spell guards to AddSpell, RemoveSpell, and Cast — fixes a latent NullRef on missing/typo spell ids
+
+## Design doc
+`docs/superpowers/specs/2026-05-10-spell-as-item-design.md`
+
+## Test plan
+- [x] `dotnet build` clean
+- [x] `dotnet test` passing
+- [x] Full Convert completes without exceptions
+- [x] Mapped-effect scroll grants and applies its effect on use
+- [x] Reusable: scroll persists after use
+- [x] Duplicate AddSpell calls cap at one item
+- [x] Unmapped-effect scroll appears with `[unimplemented]` in description
+- [x] Existing Ability/Curse/Disease/Blight/Corprus + Cast paths unchanged
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 10.3: Surface PR URL to user.**
+
+---
+
+## Self-review notes
+
+**Spec coverage:**
+- Architecture (spec §Architecture) → Tasks 1-3
+- Data flow build-time (spec §Data flow) → Tasks 1-3
+- Data flow runtime AddSpell (spec) → Tasks 4, 7
+- Data flow runtime RemoveSpell (spec) → Tasks 5, 7
+- Goods row construction table (spec §Goods row construction) → Task 2
+- Null-spell guard latent bug fix (spec §Error handling) → Tasks 4, 5, 6, 7
+- Inert scrolls with `[unimplemented]` suffix → Task 2 (`BuildScrollDescription`)
+- Build-time tests → Task 8
+- In-game smoke tests → Task 9
+- Pre-PR test gate → Task 8 + saved feedback memory
+
+**Out of scope (per spec):** mapping additional MagicEffects, mana-cost gating, Power semantics, `Magic` table sorcery generation. Not addressed here — correctly deferred.
+
+**Type/name consistency check:**
+- `GetSpellScroll` introduced in Task 1, called in Tasks 4, 5, 7 — names match.
+- `RegisterSpellScrolls` introduced in Task 2, called in Task 3 — match.
+- `spellScrolls` field introduced in Task 1, populated in Task 2 — match.
+- `ItemInfo.OriginalType.MiscItem` used in Task 2 — Task 2 includes a fallback path if the enum value is named differently in this codebase.
+- All references to `ItemManager.cs` line numbers will drift as edits land; tasks reference the *block content*, not just line numbers, so the searches still work.

--- a/docs/superpowers/specs/2026-05-10-spell-as-item-design.md
+++ b/docs/superpowers/specs/2026-05-10-spell-as-item-design.md
@@ -1,0 +1,147 @@
+# Spell-as-Item: Design
+
+**Branch:** `spellAsItem`
+**Date:** 2026-05-10
+**Tier:** B (reusable goods items wired to existing SpEffects). The items are scroll-flavored in name but use ER's non-consuming goods semantics — `isConsume = 0`, so using one applies its SpEffect without removing the item from inventory.
+**Scope:** Replace the `AddSpell` / `RemoveSpell` stubs in `Dialog.cs` and `PapyrusEMEVD.cs` so that Morrowind Spell and Power records become reusable goods items in Elden Ring, wired to the SpEffect rows that `SpeffManager` already generates.
+
+## Problem
+
+Five of Morrowind's seven spell-record types (Ability, Curse, Disease, Blight, Corprus) already round-trip through this codebase: each gets a backing event flag, and `AddSpell` / `RemoveSpell` flips the flag, which a maintenance script reads to apply or remove the SpEffect. See `Dialog.cs:1127` and `PapyrusEMEVD.cs:991`.
+
+The remaining two — **Spell** and **Power** — fall through to a stub that emits nothing. See `Dialog.cs:1116-1147` and `PapyrusEMEVD.cs:980-1012`. The TODO comment cites missing work to map spells to inventory items.
+
+Concrete impact: any quest beat that grants or removes a Spell or Power silently no-ops. That includes Mages Guild rewards, trainer beats, punitive spell-strip events, and main-quest grants.
+
+## Approach
+
+Generate one **Goods item** per Spell/Power, marked reusable (`isConsume = 0`), capped at one per inventory (`maxRepositoryNum = 1`), and wired to the SpEffect that `SpeffManager` already produces (`refId_default = spell.row`). Replace the AddSpell/RemoveSpell stubs with calls that route through the same `AwardItemLot` / `GetOrRegisterRemoveItem` flows the working AddItem/RemoveItem paths already use.
+
+Damage and other unmapped Morrowind effects produce inert SpEffects today (`SpeffManager.cs:218-267` only handles seven cases). We accept this — the scroll still gets generated and granted, and its description is suffixed with `[unimplemented]` so the inert scrolls form a self-documenting backlog of effects to map next. This was an explicit decision: generate the item regardless, surface the gap in the description, defer effect-mapping work to a separate branch.
+
+## Architecture
+
+One new pass inside `ItemManager`. No new manager class.
+
+- `ItemManager` constructor gains a `SpeffManager` parameter (becomes its 7th dependency — wiring change in `Main.cs`).
+- New private method `RegisterSpellScrolls()` runs at the end of ItemManager construction, after the existing item-build phase.
+- New private dictionary `spellScrolls : Dictionary<string, ItemInfo>` keyed by spell id.
+- New public accessor `ItemManager.GetSpellScroll(string spellId) : ItemInfo` (returns null on miss).
+- Stub sites in `Dialog.cs:1116-1147` and `PapyrusEMEVD.cs:980-1012` are replaced with calls that mirror the existing AddItem/RemoveItem flows at `Dialog.cs:1106-1112` and `Dialog.cs:883-902`.
+- The `Cast` branch at `Dialog.cs:1148-1158` and `PapyrusEMEVD.cs:1021-1033` is **not** modified — it already works via `GiveSpEffectToPlayer(spell.row)`.
+
+## Data flow
+
+### Build-time
+
+1. `SpeffManager` constructs as today (no change). Each Spell/Power gets an SpEffect row stored on `SpeffSpell.row`.
+2. `ItemManager` constructs. After existing item processing, `RegisterSpellScrolls()` walks `speffManager.GetSpeffBySpellType(Spell)` and `GetSpeffBySpellType(Power)`. For each:
+   - Clone reusable Goods template row.
+   - Override fields per the table below.
+   - `paramanager.AddOrReplaceRow(EquipParamGoods, row)`.
+   - Build `ItemInfo` of type `Goods` with the new row id.
+   - `spellScrolls[spell.id] = itemInfo`.
+3. Layout/Dialog/Papyrus passes generate scripts. The previously empty AddSpell/RemoveSpell branches now emit AwardItemLot / event-flag instructions.
+
+### Runtime
+
+**`AddSpell "fireball"` in dialog →**
+```
+ItemInfo scroll = itemManager.GetSpellScroll("fireball");
+int lotRow = paramanager.GenerateAddItemLot(scroll, 1);
+// emitted: AwardItemLot(lotRow)
+```
+Player gets one "Scroll of Fireball". Subsequent calls hit the `maxRepositoryNum=1` cap silently.
+
+**`RemoveSpell "fireball"` →**
+```
+ItemInfo scroll = itemManager.GetSpellScroll("fireball");
+Script.Flag removeFlag = scriptManager.common.GetOrRegisterRemoveItem(scroll, 1);
+// emitted: SetEventFlag({removeFlag.id}, FlagState.On)
+```
+Existing common-event remove-item handler picks up the flag and calls `RemoveItemFromPlayer(Goods, scrollRow, 1)`.
+
+**`Use scroll` (player action) →** ER's standard goods-use logic fires `refId_default` → applies the SpEffect → buff/heal/inert effect for its duration. `isConsume=0` keeps the scroll in inventory.
+
+**`Cast "fireball"` (NPC at player) →** unchanged.
+
+## Goods row construction
+
+**Template:** clone an existing reusable-buff Goods row from base ER. Selected at implementation time by inspection — the chosen template only contributes audio/menu-category defaults since the meaningful fields are all overwritten.
+
+**Field overrides per scroll:**
+
+| Field | Value |
+|---|---|
+| `refId_default` | `spell.row` (existing SpEffect id) |
+| `isConsume` | `0` |
+| `maxNum` | `1` |
+| `maxRepositoryNum` | `1` |
+| `iconId` | from `IconManager.BuffInfo` for the spell's primary effect (mirrors `SpeffManager.cs:205-206`); `-1` if no match |
+| name (FMG) | `"Scroll of {SpellName}"` |
+| description (FMG) | auto-generated effect summary; suffixed with `[unimplemented]` if no effect cases mapped |
+| `goodsCategory` | template default |
+
+Naming is the same pattern for both Spell and Power records — no cosmetic differentiation. If once-per-day Power semantics are added later, they will be distinguished behaviorally and naming can follow then.
+
+**ID range:** scrolls allocate from a contiguous block in EquipParamGoods that doesn't collide with vanilla rows or other generated items. Exact base id is locked in at implementation time by inspecting `Paramanager`'s existing allocation conventions and choosing the next free band.
+
+## Error handling
+
+**Null-spell guard (latent bug fix):** `Dialog.cs:1118` calls `GetSpellSpeff(...)` then accesses `.spellType` with no null check. A typo'd or deleted spell reference NullRefs at build. Fix: guard with `if (spell == null) { Lort.Log warning; break; }` in AddSpell, RemoveSpell, and the adjacent Cast block. Same fix applied to `PapyrusEMEVD.cs`.
+
+**Scroll lookup miss:** `GetSpellScroll(id)` returns null only if a spell exists but RegisterSpellScrolls didn't process it. Defensive: log warning and skip emitting AwardItemLot. Asymmetric with the existing `GetItem` at `Dialog.cs:897` (which throws on miss) — for scrolls a missing entry shouldn't kill the build, since the SpEffect-only path was the working baseline.
+
+**Inert scrolls (unmapped effects):** generated as designed. Description suffix `[unimplemented]` makes them greppable from FMG dump. No build-time warning — the count would be in the hundreds.
+
+**Duplicate AddSpell calls:** handled by `maxRepositoryNum=1`. Game silently caps. No script-side dedup.
+
+**RemoveSpell when player doesn't have scroll:** `RemoveItemFromPlayer` no-ops on missing items. Matches Morrowind's "remove from known list, skip if not known" semantics.
+
+**Save-game compatibility:** new scrolls only appear when AddSpell beats fire on this build. Existing save-files in mid-progress will not retroactively get scrolls for past quest beats — same compat story every other build has.
+
+**Build-time failure modes:**
+- Goods template row not found → throw with clear message naming the template id; build fails fast.
+- ID range collision at insertion → `AddOrReplaceRow` surfaces immediately.
+
+**Working paths untouched:** Ability/Curse/Disease/Blight/Corprus/Cast all branch before the new code. The diff is purely additive on the Spell/Power branch. No regression risk for the five working types.
+
+## Testing
+
+No meaningful unit-test coverage exists at this layer — `JortPob.Tests` is sparse and ItemManager/SpeffManager have heavy constructor dependencies that block isolated tests without refactor. Verification is build-time + in-game.
+
+### Build-time
+
+1. Full `Convert()` completes without exceptions.
+2. New goods row count == count of SpeffSpell of type Spell or Power.
+3. FMG text bank contains "Scroll of X" entries; descriptions end with `[unimplemented]` for unmapped-effect spells.
+4. Diff emitted EMEVD/ESD around AddSpell/RemoveSpell call sites — confirm `AwardItemLot(...)` and `SetEventFlag(...)` instructions now appear where the stubs were.
+
+### In-game smoke tests (manual)
+
+1. **Mapped-effect grant:** trigger an AddSpell beat for a Restore-family spell. Verify scroll appears, use it, verify HP increases.
+2. **Unmapped-effect grant:** same flow with a damage spell. Verify scroll appears with `[unimplemented]` description; using it does nothing visible.
+3. **RemoveSpell:** trigger a script that removes a spell. Verify scroll disappears from inventory.
+4. **Reusability:** use a buff scroll twice. Verify buff reapplies and scroll persists.
+5. **Duplicate grant:** trigger AddSpell for the same spell twice. Verify exactly one scroll in inventory.
+
+### Regression
+
+6. NPC casts a spell at player (existing Cast path). Verify SpEffect still applies.
+7. Quest beat involving Ability/Curse/Disease. Verify the maintenance-script flag flow still works.
+
+### Pre-PR gate
+
+Before opening the PR, run the existing test suite (`dotnet test` against `JortPob.Tests`) and confirm passing. The suite is sparse today (one test in `DescribeUtility`), but passing the existing tests is a hard floor — non-negotiable, surfaced to the user before push.
+
+### Out of scope
+
+Automated tests for param-row construction, FMG generation, and stub emission. The build itself is the test for those. Adding focused unit tests requires an ItemManager refactor and is tracked separately.
+
+## Out-of-scope (intentionally)
+
+- Mapping additional MagicEffect cases (Damage*, Paralyze, Charm, Levitate, etc.) to SpEffect fields. Tracked as a follow-up; this branch surfaces the inert scrolls so the backlog is visible.
+- Mana-cost gating on scroll use. Reusable + free is acknowledged as more permissive than Morrowind's magicka-cost model; revisit when (if) cost-gating is introduced.
+- Once-per-day Power semantics. Powers are reusable in this branch like Spells; per agreed scope.
+- Generating real ER `Magic` table sorcery/incantation entries (tier-3 work).
+- Refactoring ItemManager's constructor dependency list.

--- a/docs/superpowers/specs/2026-05-10-spell-as-item-design.md
+++ b/docs/superpowers/specs/2026-05-10-spell-as-item-design.md
@@ -23,7 +23,7 @@ Damage and other unmapped Morrowind effects produce inert SpEffects today (`Spef
 
 One new pass inside `ItemManager`. No new manager class.
 
-- `ItemManager` constructor gains a `SpeffManager` parameter (becomes its 7th dependency — wiring change in `Main.cs`).
+- `ItemManager` already takes `SpeffManager` as its 4th constructor parameter (`ItemManager.cs:54`). No new dependency, no Main.cs wiring change.
 - New private method `RegisterSpellScrolls()` runs at the end of ItemManager construction, after the existing item-build phase.
 - New private dictionary `spellScrolls : Dictionary<string, ItemInfo>` keyed by spell id.
 - New public accessor `ItemManager.GetSpellScroll(string spellId) : ItemInfo` (returns null on miss).
@@ -67,7 +67,7 @@ Existing common-event remove-item handler picks up the flag and calls `RemoveIte
 
 ## Goods row construction
 
-**Template:** clone an existing reusable-buff Goods row from base ER. Selected at implementation time by inspection — the chosen template only contributes audio/menu-category defaults since the meaningful fields are all overwritten.
+**Template:** clone `EquipParamGoods` row `2000900` (Divine Blessing). Already used as a goods template elsewhere in `ItemManager` (`ItemManager.cs:741`). Meaningful fields are all overridden below; template choice affects only sound/menu-category defaults.
 
 **Field overrides per scroll:**
 
@@ -84,7 +84,9 @@ Existing common-event remove-item handler picks up the flag and calls `RemoveIte
 
 Naming is the same pattern for both Spell and Power records — no cosmetic differentiation. If once-per-day Power semantics are added later, they will be distinguished behaviorally and naming can follow then.
 
-**ID range:** scrolls allocate from a contiguous block in EquipParamGoods that doesn't collide with vanilla rows or other generated items. Exact base id is locked in at implementation time by inspecting `Paramanager`'s existing allocation conventions and choosing the next free band.
+**ID range:** allocate via the existing `nextGoodsId` counter in `ItemManager` (starts at 30000, increments by 10 per row — `ItemManager.cs:67`, line 275). Spell scrolls register *after* the existing goods-generation pass so they consume the next free contiguous block, no collision.
+
+**Template:** clone `EquipParamGoods` row `2000900` (Divine Blessing) — already used as a goods template elsewhere in `ItemManager` (line 741). All meaningful fields are overridden so template choice mostly affects sound/menu-category defaults.
 
 ## Error handling
 


### PR DESCRIPTION
## Summary

Replaces the `AddSpell` / `RemoveSpell` stubs in `Dialog.cs` and `PapyrusEMEVD.cs` so quest beats that grant or remove a Morrowind Spell or Power now produce a reusable scroll item in the player's inventory.

- Each spell scroll is generated once during `ItemManager` construction and wired via `refId_default` to the SpEffect that `SpeffManager` already produces. Using the scroll fires the SpEffect (heal/buff for mapped effects; inert for unmapped).
- `isConsume = 0`, `maxNum = 1`, `maxRepositoryNum = 1` make the scroll reusable, capped at one per spell — duplicate `AddSpell` calls silently no-op.
- Spells whose effects are not yet mapped to SpEffect fields get a description suffix `[unimplemented]` so the inert scrolls form a self-documenting punch list of `MagicEffect` cases to map next.
- Adds null-spell guards to `AddSpell`, `RemoveSpell`, and `Cast` — fixes a latent NullRef on missing/typo'd spell ids in all three paths.

## Design + plan

- Spec: `docs/superpowers/specs/2026-05-10-spell-as-item-design.md`
- Implementation plan: `docs/superpowers/plans/2026-05-10-spell-as-item.md`

## Files touched

- `JortPob/ItemManager.cs` — adds `RegisterSpellScrolls()` + 2 helpers, `spellScrolls` dict, `GetSpellScroll(id)` accessor, single ctor wire-up.
- `JortPob/ESM/Dialog.cs` — replaces AddSpell + RemoveSpell stubs; null-guards Cast.
- `JortPob/PapyrusEMEVD.cs` — same three changes for the EMEVD path.

7 implementation commits total, intentionally split so `git bisect` against any regression points cleanly at the introducing change.

## Test plan

### Done
- [x] `dotnet build` clean (0 errors, 35 pre-existing warnings, 0 new warnings)
- [x] `dotnet test` passing (1/1, baseline `LinearToSRGBShouldConvertCorrectly`)
- [x] Per-commit spec compliance review
- [x] Per-commit code quality review

### Deferred (not run by author — no local Morrowind/ER unpack environment)
- [ ] Full `Convert()` completes without exceptions
- [ ] Mapped-effect scroll grants and applies its effect on use
- [ ] Reusable: scroll persists after use (`isConsume=0`)
- [ ] Duplicate `AddSpell` calls cap at one item (`maxRepositoryNum=1`)
- [ ] Unmapped-effect scroll appears with `[unimplemented]` in description
- [ ] Existing Ability/Curse/Disease/Blight/Corprus + Cast paths unchanged

In-game smoke testing is intentionally deferred to a reviewer with a working setup. The diff is small and surgical; if the smoke test surfaces issues I'll address them in follow-up commits on this branch.

## Out of scope (per spec)

- Mapping additional `MagicEffect` cases (`Damage*`, `Paralyze`, `Charm`, `Levitate`, etc.) — the `[unimplemented]` description suffix surfaces this backlog.
- Mana-cost gating on scroll use.
- Once-per-day Power semantics (Powers are reusable like Spells in this branch).
- Generating real ER `Magic` table sorcery/incantation entries.