### PR TITLE
Fixed compiler warnings, simplified json override classes

### DIFF
--- a/JortPob.Tests/JortPob.Tests.csproj
+++ b/JortPob.Tests/JortPob.Tests.csproj
@@ -13,6 +13,7 @@
       For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
       -->
     <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/JortPob.sln
+++ b/JortPob.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.14.36109.1
+# Visual Studio Version 18
+VisualStudioVersion = 18.5.11723.231 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JortPob", "JortPob\JortPob.csproj", "{DDE52499-9E38-4B69-8699-EB017AB55551}"
 EndProject
@@ -12,21 +12,35 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{DDE52499-9E38-4B69-8699-EB017AB55551}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DDE52499-9E38-4B69-8699-EB017AB55551}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DDE52499-9E38-4B69-8699-EB017AB55551}.Debug|x64.ActiveCfg = Debug|x64
+		{DDE52499-9E38-4B69-8699-EB017AB55551}.Debug|x64.Build.0 = Debug|x64
 		{DDE52499-9E38-4B69-8699-EB017AB55551}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DDE52499-9E38-4B69-8699-EB017AB55551}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DDE52499-9E38-4B69-8699-EB017AB55551}.Release|x64.ActiveCfg = Release|x64
+		{DDE52499-9E38-4B69-8699-EB017AB55551}.Release|x64.Build.0 = Release|x64
 		{807E75F9-9521-49CF-8CA4-F55637CCD69C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{807E75F9-9521-49CF-8CA4-F55637CCD69C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{807E75F9-9521-49CF-8CA4-F55637CCD69C}.Debug|x64.ActiveCfg = Debug|x64
+		{807E75F9-9521-49CF-8CA4-F55637CCD69C}.Debug|x64.Build.0 = Debug|x64
 		{807E75F9-9521-49CF-8CA4-F55637CCD69C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{807E75F9-9521-49CF-8CA4-F55637CCD69C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{807E75F9-9521-49CF-8CA4-F55637CCD69C}.Release|x64.ActiveCfg = Release|x64
+		{807E75F9-9521-49CF-8CA4-F55637CCD69C}.Release|x64.Build.0 = Release|x64
 		{82229A83-8715-41B4-BE39-76F493A99694}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{82229A83-8715-41B4-BE39-76F493A99694}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82229A83-8715-41B4-BE39-76F493A99694}.Debug|x64.ActiveCfg = Debug|x64
+		{82229A83-8715-41B4-BE39-76F493A99694}.Debug|x64.Build.0 = Debug|x64
 		{82229A83-8715-41B4-BE39-76F493A99694}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{82229A83-8715-41B4-BE39-76F493A99694}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82229A83-8715-41B4-BE39-76F493A99694}.Release|x64.ActiveCfg = Release|x64
+		{82229A83-8715-41B4-BE39-76F493A99694}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/JortPob/Common/Audio.cs
+++ b/JortPob/Common/Audio.cs
@@ -116,7 +116,7 @@ namespace JortPob.Common
                     // If processes succeeded but the file isn't there, something is wrong, we retry
                     throw new FileNotFoundException($"WEM file was not found after successful conversion: {wemPath}");
                 }
-                catch (Exception ex)
+                catch
                 {
                     // Keep retrying. Don't spam log after every failed generation as it's bloat.
                     // If we fail up to MAX_RETRY then we throw an exception and print log.

--- a/JortPob/Common/MapGenerator.cs
+++ b/JortPob/Common/MapGenerator.cs
@@ -140,9 +140,9 @@ namespace JortPob.Common
             {
                 if (mapTileTpfBxf == null || mapTileTpfBxf.Files.Count == 0) throw new FileNotFoundException("Map files weren't loaded correctly");
 
-                BinderFile? l0File = mapTileTpfBxf.Files.FirstOrDefault(f => f.Name.Contains("MENU_MapTile_M00_L0_00_00_00000000"));
-                BinderFile? l1File = mapTileTpfBxf.Files.FirstOrDefault(f => f.Name.Contains("MENU_MapTile_M00_L1_00_00_00000000"));
-                BinderFile? l2File = mapTileTpfBxf.Files.FirstOrDefault(f => f.Name.Contains("MENU_MapTile_M00_L2_00_00_00000000"));
+                BinderFile l0File = mapTileTpfBxf.Files.FirstOrDefault(f => f.Name.Contains("MENU_MapTile_M00_L0_00_00_00000000"));
+                BinderFile l1File = mapTileTpfBxf.Files.FirstOrDefault(f => f.Name.Contains("MENU_MapTile_M00_L1_00_00_00000000"));
+                BinderFile l2File = mapTileTpfBxf.Files.FirstOrDefault(f => f.Name.Contains("MENU_MapTile_M00_L2_00_00_00000000"));
 
                 if (l0File != null)
                 {
@@ -227,7 +227,7 @@ namespace JortPob.Common
                     g.DrawImage(workingImage, 0, 0, targetSize, targetSize);
                 }
 
-                Bitmap? blankTile = zoomLevel switch
+                Bitmap blankTile = zoomLevel switch
                 {
                     ZoomLevel.L0 => blankTileL0,
                     ZoomLevel.L1 => blankTileL1,

--- a/JortPob/Common/Obj.cs
+++ b/JortPob/Common/Obj.cs
@@ -20,7 +20,7 @@ namespace JortPob.Common
 
         public Obj(string path)
         {
-            ObjG? last = null;
+            ObjG last = null;
             string[] data = File.ReadAllLines(path);
             foreach (string line in data)
             {

--- a/JortPob/Common/SAM.cs
+++ b/JortPob/Common/SAM.cs
@@ -215,7 +215,7 @@ namespace JortPob.Common
                     // If processes succeeded but the file isn't there, something is wrong, we retry
                     throw new FileNotFoundException($"WEM file was not found after successful conversion: {wemPath}");
                 }
-                catch (Exception ex)
+                catch
                 {
                     // Keep retrying. Don't spam log after every failed generation as it's bloat.
                     // If we fail up to MAX_RETRY then we throw an exception and print log.

--- a/JortPob/Common/SillyJsonUtils.cs
+++ b/JortPob/Common/SillyJsonUtils.cs
@@ -42,38 +42,36 @@ namespace JortPob.Common
 
         public static void ModifyRow(FsParam.Row row, Dictionary<string, string> data)
         {
-            foreach (KeyValuePair<string, string> property in data)
+            foreach (var (key, value) in data)
             {
-                string key = property.Key;
-                string value = property.Value;
                 FsParam.Cell cell = (FsParam.Cell)row[key];
-                switch (cell.Value.GetType())
+                switch (cell.Value)
                 {
-                    case Type t when t == typeof(int):
+                    case int:
                         cell.SetValue(int.Parse(value));
                         break;
-                    case Type t when t == typeof(uint):
+                    case uint:
                         cell.SetValue(uint.Parse(value));
                         break;
-                    case Type t when t == typeof(ushort):
+                    case ushort:
                         cell.SetValue(ushort.Parse(value));
                         break;
-                    case Type t when t == typeof(short):
+                    case short:
                         cell.SetValue(short.Parse(value));
                         break;
-                    case Type t when t == typeof(byte):
+                    case byte:
                         cell.SetValue(byte.Parse(value));
                         break;
-                    case Type t when t == typeof(sbyte):
+                    case sbyte:
                         cell.SetValue(sbyte.Parse(value));
                         break;
-                    case Type t when t == typeof(float):
+                    case float:
                         cell.SetValue(float.Parse(value));
                         break;
-                    case Type t when t == typeof(bool):
+                    case bool:
                         cell.SetValue(bool.Parse(value));
                         break;
-                    case Type t when t == typeof(string):
+                    case string:
                         cell.SetValue(value);
                         break;
                     default:

--- a/JortPob/ESM/Content.cs
+++ b/JortPob/ESM/Content.cs
@@ -16,11 +16,11 @@ namespace JortPob
         public readonly Cell cell;
 
         public readonly string id;   // record id
-        public readonly string? name; // can be null!
+        public readonly string name; // can be null!
         public readonly ESM.Type type;
 
         public uint entity;  // entity id, usually 0
-        public string? papyrus { get; private set; } // papyrus script id if it has one (usually null)
+        public string papyrus { get; private set; } // papyrus script id if it has one (usually null)
         public Vector3 relative;
         public Int2 load; // if a piece of content needs tile load data this is where it's stored
 
@@ -28,7 +28,7 @@ namespace JortPob
         public Vector3 rotation;
         public readonly int scale;  // scale in converted to a int where 100 = 1.0f scale. IE:clamp to nearest 1%. this is to group scale for asset generation.
 
-        public string? mesh;  // can be null!
+        public string mesh;  // can be null!
 
         public Content(Cell cell, JsonNode json, Record record)
         {

--- a/JortPob/ESM/ESM.cs
+++ b/JortPob/ESM/ESM.cs
@@ -386,17 +386,17 @@ namespace JortPob
             }
         }
 
-        public JobInfo? GetJob(string id) => jobs.FirstOrDefault(job => job.id == id.ToLower());
+        public JobInfo GetJob(string id) => jobs.FirstOrDefault(job => job.id == id.ToLower());
 
-        public RaceInfo? GetRace(string id) => races.FirstOrDefault(race => race.id == id.ToLower());
+        public RaceInfo GetRace(string id) => races.FirstOrDefault(race => race.id == id.ToLower());
 
-        public FactionInfo? GetFaction(string id) => factions.FirstOrDefault(faction => faction.id == id.ToLower());
+        public FactionInfo GetFaction(string id) => factions.FirstOrDefault(faction => faction.id == id.ToLower());
 
-        public SoundInfo? GetSound(string id) => sounds.FirstOrDefault(sound => sound.id == id.ToLower());
+        public SoundInfo GetSound(string id) => sounds.FirstOrDefault(sound => sound.id == id.ToLower());
 
-        public Papyrus? GetPapyrus(string? id) => id is null ? null : scripts.FirstOrDefault(script => script.id == id.ToLower());
+        public Papyrus GetPapyrus(string id) => id is null ? null : scripts.FirstOrDefault(script => script.id == id.ToLower());
 
-        public LeveledCreature? GetLeveledCreature(string id) => leveled.FirstOrDefault(lc => lc.id == id.ToLower());
+        public LeveledCreature GetLeveledCreature(string id) => leveled.FirstOrDefault(lc => lc.id == id.ToLower());
 
         /* Get dialog and character data for building esd */
         public List<Tuple<DialogRecord, List<DialogInfoRecord>>> GetDialog(ScriptManager scriptManager, CharacterContent npc)

--- a/JortPob/ESM/Papyrus.cs
+++ b/JortPob/ESM/Papyrus.cs
@@ -478,7 +478,7 @@ namespace JortPob
                     parameters = ps.ToArray();
                 }
                 // Handle variable
-                else if (!Enum.TryParse(typeof(Type), sanitize.Split(" ")[0], true, out object? callTest))
+                else if (!Enum.TryParse(typeof(Type), sanitize.Split(" ")[0], true, out object _))
                 {
                     type = Type.Variable;
                     parameters = Utility.StringAwareSplit(sanitize, ' ');

--- a/JortPob/JortPob.csproj
+++ b/JortPob/JortPob.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net9.0-windows</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
@@ -92,44 +93,6 @@
       <HintPath>DLL\ZstdNet.dll</HintPath>
     </Reference>
   </ItemGroup>
-
-  <!-- DLLs -->
-	<Target Name="CopyFileToRoot" AfterTargets="AfterBuild">
-		<Copy SourceFiles="DLL\BouncyCastle.Cryptography.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\DrSwizzler.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\ERNavmeshGen.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\ERNavmeshGenCS.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\ESDLang.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\esdtool.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\HKLib.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\HKLib.Reflection.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\HKLib.Serialization.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\HkxUpgradeLib.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\IronPython.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\IronPython.Modules.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\IronPython.SQLite.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\IronPython.Wpf.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\keystone.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\libzstd.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\Microsoft.Dynamic.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\Microsoft.Scripting.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\Microsoft.Scripting.Metadata.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\Mono.Unix.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\NativeFileDialogSharp.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\Newtonsoft.Json.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\nfd.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\SoulsAssetPipeline.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\SoulsFormats.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\SoulsIds.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\StudioUtils.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\System.CodeDom.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\tes3-interop.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\tes3.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\Tommy.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\WitchyFormats.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\ZstdNet.dll" DestinationFolder="$(OutDir)" />
-		<Copy SourceFiles="DLL\Zydis.dll" DestinationFolder="$(OutDir)" />
-	</Target>
 	
   <!-- Resources -->
   <ItemGroup>

--- a/JortPob/LiquidManager.cs
+++ b/JortPob/LiquidManager.cs
@@ -1842,17 +1842,6 @@ namespace JortPob
                                             return false;
                                         }
 
-                                        /* test the new edges of this triangle, skip outline edge */ // not used
-                                        bool BaseSkipIntersectTest(WetFace f)
-                                        {
-                                            foreach (WetEdge cutedge in cutout.Edges())
-                                            {
-                                                if (!cutedge.Intersection(new WetEdge(f.a, f.b), false).IsNaN()) { return true; }
-                                                if (!cutedge.Intersection(new WetEdge(f.c, f.b), false).IsNaN()) { return true; }
-                                            }
-                                            return false;
-                                        }
-
                                         /* Check if they are valid, then add them if they are */
                                         cutout.size -= 0.1f;
                                         if (nf1 != null && !nf1.IsIntersect(edges) && !nf1.IsDegenerate() && !InsideCutout(nf1) && !nf1.IsIntersect(cutout.Edges())) { newFaces.Add(nf1); edges.AddRange(nf1.Edges()); }
@@ -2440,6 +2429,11 @@ namespace JortPob
 
                 return false;
             }
+
+            public override int GetHashCode()
+            {
+                return HashCode.Combine(a, b);
+            }
         }
 
         public class WetEdge
@@ -2517,6 +2511,11 @@ namespace JortPob
                 }
 
                 return Vector3.NaN; // no intersection
+            }
+
+            public override int GetHashCode()
+            {
+                return HashCode.Combine(a, b);
             }
         }
     }

--- a/JortPob/LiveParam.cs
+++ b/JortPob/LiveParam.cs
@@ -128,7 +128,8 @@ namespace FSParam
         {
             internal LiveParam Parent;
             public int ID { get; set; }
-            public string? Name { get; set; }
+            // May be null
+            public string Name { get; set; }
             internal uint DataIndex;
 
             public IEnumerable<Column> Cells => Parent.Cells;
@@ -149,7 +150,7 @@ namespace FSParam
 
             public PARAMDEF Def => Parent.AppliedParamdef;
 
-            internal Row(int id, string? name, LiveParam parent, uint dataIndex)
+            internal Row(int id, string name, LiveParam parent, uint dataIndex)
             {
                 ID = id;
                 Name = name;
@@ -183,7 +184,7 @@ namespace FSParam
                 clone.Parent._paramData.CopyData(Parent._paramData, DataIndex, clone.DataIndex);
             }
 
-            public bool DataEquals(Row? other)
+            public bool DataEquals(Row other)
             {
                 if (other == null)
                     return false;
@@ -546,7 +547,7 @@ namespace FSParam
             _rows.Insert(index, row);
         }
 
-        public int IndexOfRow(Row? row)
+        public int IndexOfRow(Row row)
         {
             if (row == null || row.Parent != this)
                 throw new ArgumentException();
@@ -746,7 +747,7 @@ namespace FSParam
             {
                 long nameOffset;
                 int id;
-                string? name = null;
+                string name = null;
                 uint dataIndex;
                 if (Format2D.HasFlag(FormatFlags1.LongDataOffset))
                 {
@@ -958,7 +959,7 @@ namespace FSParam
         /// Gets the index of the Row with ID id or returns null
         /// </summary>
         /// <param name="id">The ID of the row to find</param>
-        public Row? this[int id]
+        public Row this[int id]
         {
             get
             {
@@ -972,7 +973,7 @@ namespace FSParam
             }
         }
 
-        public Column? this[string name] => Cells.FirstOrDefault(cell => cell.Def.InternalName == name);
+        public Column this[string name] => Cells.FirstOrDefault(cell => cell.Def.InternalName == name);
         public static bool IsBitType(PARAMDEF.DefType type)
         {
             switch (type)

--- a/JortPob/NpcManager.cs
+++ b/JortPob/NpcManager.cs
@@ -34,8 +34,6 @@ namespace JortPob
         private readonly Dictionary<string, int> topicText; // topic text id map
         private readonly List<EsdInfo> esds; // npcs, beds
 
-        private readonly Dictionary<string, int> npcParamMap, npcThinkParamMap;
-
         private int nextNpcParamId, nextNpcThinkParamId, nextCharInitId;  // increment by 10
         private int nextBedId;
 

--- a/JortPob/Override.cs
+++ b/JortPob/Override.cs
@@ -1,10 +1,12 @@
 ﻿using JortPob.Common;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 
 namespace JortPob
 {
@@ -152,527 +154,157 @@ namespace JortPob
         public static void Initialize()
         {
             /* Load do_not_place overrides */
-            JsonNode jsonDoNotPlace = JsonNode.Parse(File.ReadAllText(Utility.ResourcePath(@"overrides\do_not_place.json")));
-            DO_NOT_PLACE = jsonDoNotPlace != null
-                ? jsonDoNotPlace.AsArray().Select(node => node.ToString().ToLower()).ToHashSet()
-                : [];
+            DO_NOT_PLACE = JsonConvert.DeserializeObject<List<string>>(File.ReadAllText(Utility.ResourcePath(@"overrides\do_not_place.json")))
+                .Select(dnp => dnp.ToLower()).ToHashSet();
 
             /* Load static_collision overrides */
-            JsonNode jsonStaticCollision = JsonNode.Parse(File.ReadAllText(Utility.ResourcePath(@"overrides\static_collision.json")));
-            STATIC_COLLISION = jsonStaticCollision != null
-                ? jsonStaticCollision.AsArray().Select(node => node.ToString().ToLower()).ToHashSet()
-                : [];
+            STATIC_COLLISION = JsonConvert.DeserializeObject<List<string>>(File.ReadAllText(Utility.ResourcePath(@"overrides\static_collision.json")))
+                .Select(sc => sc.ToLower()).ToHashSet();
 
             /* Load items_to_skip overrides */
-            JsonNode jsonItemsToSkip = JsonNode.Parse(File.ReadAllText(Utility.ResourcePath(@"overrides\items_to_skip.json")));
-            ITEMS_TO_SKIP = jsonItemsToSkip != null
-                ? jsonItemsToSkip.AsArray().Select(node => node.ToString().ToLower()).ToHashSet()
-                : [];
+            ITEMS_TO_SKIP = JsonConvert.DeserializeObject<List<string>>(File.ReadAllText(Utility.ResourcePath(@"overrides\items_to_skip.json")))
+                .Select(its => its.ToLower()).ToHashSet();
 
             /* Load items_to_skip overrides */
-            JsonNode jsonCustomVoiceList = JsonNode.Parse(File.ReadAllText(Utility.ResourcePath(@"overrides\custom_voice_list.json")));
-            CUSTOM_VOICES = jsonCustomVoiceList != null
-                ? jsonCustomVoiceList.AsArray().Select(node => node.ToString().ToLower()).ToHashSet()
-                : [];
+            CUSTOM_VOICES = JsonConvert.DeserializeObject<List<string>>(File.ReadAllText(Utility.ResourcePath(@"overrides\custom_voice_list.json")))
+                .Select(cv => cv.ToLower()).ToHashSet();
 
             /* Load character creation class overrides */
-            CHARACTER_CREATION_CLASS = new();
-            JsonArray jsonCharCreaClass = JsonNode.Parse(File.ReadAllText(Utility.ResourcePath(@"overrides\character_creation_class.json"))).AsArray();
-            foreach(JsonNode node in jsonCharCreaClass)
-            {
-                PlayerClass pc = new(node);
-                CHARACTER_CREATION_CLASS.Add(pc);
-            }
+            CHARACTER_CREATION_CLASS = JsonConvert.DeserializeObject<List<PlayerClass>>(File.ReadAllText(Utility.ResourcePath(@"overrides\character_creation_class.json"))).ToList();
 
             /* Load character creation gift overrides */
-            CHARACTER_CREATION_GIFT = new();
-            JsonArray jsonCharCreaGift = JsonNode.Parse(File.ReadAllText(Utility.ResourcePath(@"overrides\character_creation_gift.json"))).AsArray();
-            foreach (JsonNode node in jsonCharCreaGift)
-            {
-                Gift gift = new(node);
-                CHARACTER_CREATION_GIFT.Add(gift);
-            }
+            CHARACTER_CREATION_GIFT = JsonConvert.DeserializeObject<List<Gift>>(File.ReadAllText(Utility.ResourcePath(@"overrides\character_creation_gift.json")));
 
             /* Load character creation race overrides */
-            CHARACTER_CREATION_RACE = JsonSerializer.Deserialize<List<PlayerRace>>(File.ReadAllText(Utility.ResourcePath(@"overrides\character_creation_race.json")), new JsonSerializerOptions { IncludeFields = true });
+            CHARACTER_CREATION_RACE = JsonConvert.DeserializeObject<List<PlayerRace>>(File.ReadAllText(Utility.ResourcePath(@"overrides\character_creation_race.json")));
 
             /* Load alchemy recipe information */
-            ALCHEMY_INFOS = new();
-            JsonNode jsonAlchemyInfo = JsonNode.Parse(File.ReadAllText(Utility.ResourcePath(@"overrides\alchemy.json")));
-            foreach (var property in jsonAlchemyInfo.AsObject())
-            {
-                JsonNode jsonNode = property.Value;
-                AlchemyInfo alchy = new(property.Key, jsonNode);
-                ALCHEMY_INFOS.Add(alchy);
-            }
+            ALCHEMY_INFOS = JsonConvert.DeserializeObject<List<AlchemyInfo>>(File.ReadAllText(Utility.ResourcePath(@"overrides\alchemy.json")));
 
             /* Load weapon skill information list */
-            SKILL_INFOS = new();
-            JsonNode jsonSkillInfo = JsonNode.Parse(File.ReadAllText(Utility.ResourcePath(@"overrides\weapon_skill_info.json")));
-            foreach(JsonNode jsonNode in jsonSkillInfo.AsArray())
-            {
-                SkillInfo skillInfo = new(jsonNode);
-                SKILL_INFOS.Add(skillInfo);
-            }
+            SKILL_INFOS = JsonConvert.DeserializeObject<List<SkillInfo>>(File.ReadAllText(Utility.ResourcePath(@"overrides\weapon_skill_info.json")));
 
             /* Load spell remapping list */
-            SPELL_REMAPS_BY_ID = new();
-            JsonNode jsonSpellRemap = JsonNode.Parse(File.ReadAllText(Utility.ResourcePath(@"overrides\spell_remap.json")));
-            foreach (var property in jsonSpellRemap.AsObject())
-            {
-                JsonNode jsonNode = property.Value;
-                SpellRemap sprmo = new(property.Key, jsonNode);
-                SPELL_REMAPS_BY_ID.Add(sprmo.id, sprmo);
-            }
+            SPELL_REMAPS_BY_ID = JsonConvert.DeserializeObject<Dictionary<string, SpellRemap>>(File.ReadAllText(Utility.ResourcePath(@"overrides\spell_remap.json")));
 
             /* Load item remapping list */
-            ITEM_REMAPS_BY_ID = new();
-            string[] itemRemapFiles = Directory.GetFiles(Utility.ResourcePath(@"overrides\items\remap"));
-            foreach (string itemRemapFile in itemRemapFiles)
-            {
-                JsonNode itemRemapJson = JsonNode.Parse(File.ReadAllText(itemRemapFile));
-                foreach (var property in itemRemapJson.AsObject())
-                {
-                    JsonNode jsonNode = property.Value;
-                    ItemRemap itrmo = new(property.Key, jsonNode);
-                    ITEM_REMAPS_BY_ID.Add(itrmo.id, itrmo);
-                }
-            }
+            ITEM_REMAPS_BY_ID = Directory.GetFiles(Utility.ResourcePath(@"overrides\items\remap"))
+                .Select(file => JsonConvert.DeserializeObject<List<ItemRemap>>(File.ReadAllText(file)))
+                .SelectMany(list => list)
+                .ToDictionary(remap => remap.id);
 
             /* Load all item definitinos from resources/override/items */
-            string[] itemFiles = Directory.GetFiles(Utility.ResourcePath(@"overrides\items"));
-            ITEM_DEFINITIONS_BY_ID = new();
-            foreach (string itemFile in itemFiles)
-            {
-                ItemDefinition definition = new(itemFile);
-                ITEM_DEFINITIONS_BY_ID.Add(definition.id, definition);
-            }
+            ITEM_DEFINITIONS_BY_ID = Directory.GetFiles(Utility.ResourcePath(@"overrides\items"))
+                .Select(file =>
+                { 
+                    var obj = JsonConvert.DeserializeObject<ItemDefinition>(File.ReadAllText(file));
+                    obj.id = Path.GetFileNameWithoutExtension(file);
+                    return obj;
+                })
+                .ToDictionary(def => def.id);
 
             /* Load all speff definitinos from resources/override/speffs */
-            string[] speffFiles = Directory.GetFiles(Utility.ResourcePath(@"overrides\speffs"));
-            SPEFF_DEFINITIONS_BY_ID = new();
-            foreach (string speffFile in speffFiles)
-            {
-                SpeffDefinition definition = new(speffFile);
-                SPEFF_DEFINITIONS_BY_ID.Add(definition.id, definition);
-            }
+            SPEFF_DEFINITIONS_BY_ID = Directory.GetFiles(Utility.ResourcePath(@"overrides\speffs"))
+                .Select(file =>
+                {
+                    var obj = JsonConvert.DeserializeObject<SpeffDefinition>(File.ReadAllText(file));
+                    obj.id = Path.GetFileNameWithoutExtension(file);
+                    return obj;
+                })
+                .ToDictionary(def => def.id);
 
             /* Load enemy remap list */
-            ENEMY_REMAPS = new();
-            JsonNode jsonEnemyRemaps = JsonNode.Parse(File.ReadAllText(Utility.ResourcePath(@"overrides\enemy_remap.json")));
-            foreach (var property in jsonEnemyRemaps.AsObject())
-            {
-                JsonNode jsonNode = property.Value;
-                EnemyRemap enemyRemap = new(property.Key, jsonNode);
-                ENEMY_REMAPS.Add(enemyRemap);
-            }
+            ENEMY_REMAPS = JsonConvert.DeserializeObject<List<EnemyRemap>>(File.ReadAllText(Utility.ResourcePath(@"overrides\enemy_remap.json")));
 
             /* Load map icon overrides */
-            MAP_ICONS = new();
-            JsonNode jsonMapIcons = JsonNode.Parse(File.ReadAllText(Utility.ResourcePath(@"overrides\map_icons.json")));
-            foreach (var property in jsonMapIcons.AsObject())
-            {
-                string iconName = property.Value.GetValue<string>();
-                MAP_ICONS.Add(property.Key.ToLower().Trim(), Enum.Parse<Layout.MapPoint.Icon>(iconName));
-            }
+            MAP_ICONS = JsonConvert.DeserializeObject<Dictionary<string, Layout.MapPoint.Icon>>(File.ReadAllText(Utility.ResourcePath(@"overrides\map_icons.json")));
 
             /* Load hair id remap to elden ring hair part ids */
-            HAIR_REMAP = new();
-            JsonNode jsonHairRemap = JsonNode.Parse(File.ReadAllText(Utility.ResourcePath(@"overrides\face\hair.json")));
-            foreach (var property in jsonHairRemap.AsObject())
-            {
-                JsonNode node = property.Value;
-
-                string id = property.Key.ToLower().Trim();
-                byte partId = node["part"].GetValue<byte>();
-                string colorName = node["color"].GetValue<string>().Replace(" ", "");
-                Hair.Color color = Enum.Parse<Hair.Color>(colorName, true);
-
-                HAIR_REMAP.Add(id, new(partId, color));
-            }
+            HAIR_REMAP = JsonConvert.DeserializeObject<Dictionary<string, Hair>>(File.ReadAllText(Utility.ResourcePath(@"overrides\face\hair.json")));
 
             /* Load all json files in overrides/face and stick them in a dictionary for us to grab from */
-            FACE_REMAP = new();
-            string[] faceRemapFiles = Directory.GetFiles(Utility.ResourcePath(@"overrides\face"));
-            foreach (string faceRemapFile in faceRemapFiles)
-            {
-                string fileName = Path.GetFileNameWithoutExtension(faceRemapFile).ToLower().Trim();
-                if (fileName == "hair") { continue; } // skip hair json file
-
-                JsonNode faceRemapJson = JsonNode.Parse(File.ReadAllText(faceRemapFile));
-                FaceData faceData = new(fileName, faceRemapJson);
-                FACE_REMAP.Add(faceData.id, faceData);
-            }
+            FACE_REMAP = Directory.GetFiles(Utility.ResourcePath(@"overrides\face"))
+                .Where(file => Path.GetFileNameWithoutExtension(file).ToLower().Trim() != "hair")
+                .Select(file =>
+                {
+                    var obj = JsonConvert.DeserializeObject<FaceData>(File.ReadAllText(file));
+                    obj.id = Path.GetFileNameWithoutExtension(file);
+                    return obj;
+                })
+                .ToDictionary(remap => remap.id);
 
             /* Loading tips overrides */
-            LOADING_TIPS = new();
-            JsonNode jsonLoadingTips = JsonNode.Parse(File.ReadAllText(Utility.ResourcePath(@"overrides\loading_tips.json")));
-            foreach (var property in jsonLoadingTips.AsObject())
-            {
-                JsonNode jsonNode = property.Value;
-                LoadingTip loadingTip = new(property.Key, property.Value.GetValue<string>());
-                LOADING_TIPS.Add(loadingTip);
-            }
+            LOADING_TIPS = JsonConvert.DeserializeObject<List<LoadingTip>>(File.ReadAllText(Utility.ResourcePath(@"overrides\loading_tips.json")));
 
             /* Loading region bytes */
-            REGION = new();
-            JsonNode jsonRegion = JsonNode.Parse(File.ReadAllText(Utility.ResourcePath(@"overrides\region.json")));
-            foreach(var property in jsonRegion.AsObject())
-            {
-                string id = property.Key.ToLower().Trim();
-                byte value = property.Value.GetValue<byte>();
-                REGION.Add(id, value);
-            }
+            REGION = JsonConvert.DeserializeObject<Dictionary<string, byte>>(File.ReadAllText(Utility.ResourcePath(@"overrides\region.json")));
         }
 
         /* Classes for serializing */
-        public class PlayerClass
+        public record PlayerClass(string name, string description, Dictionary<string, int> data);
+
+        public record PlayerRace(string name, string description, byte id);
+
+        public record Gift(string name, string description, Dictionary<string, int> data);
+
+        public record AlchemyInfo(string comment, string id, CharacterContent.Stats.Tier tier, List<string> ingredients);
+
+        public record SkillInfo(string comment, int row, CharacterContent.Stats.Tier tier, int value, ItemText text)
         {
-            public string name, description;
-            public readonly Dictionary<string, int> data;
-
-            public PlayerClass(JsonNode json)
-            {
-                name = json["name"].GetValue<string>();
-                description = json["description"].GetValue<string>();
-
-                data = new();
-                foreach (var property in json["data"].AsObject())
-                {
-                    data.Add(property.Key, property.Value.GetValue<int>());
-                }
-            }
-        }
-
-        public class PlayerRace
-        {
-            public string name, description;
-            public byte id;  // this id matches the values of the CharacterContent.Race enums
-
-            public PlayerRace() { }
-        }
-
-        public class Gift
-        {
-            public string name, description;
-            public readonly Dictionary<string, int> data;
-
-            public Gift(JsonNode json)
-            {
-                name = json["name"].GetValue<string>();
-                description = json["description"].GetValue<string>();
-
-                data = new();
-                foreach (var property in json["data"].AsObject())
-                {
-                    data.Add(property.Key, property.Value.GetValue<int>());
-                }
-            }
-        }
-
-        public class AlchemyInfo
-        {
-            public readonly string comment;
-            public readonly string id;
-            public readonly CharacterContent.Stats.Tier tier;
-            public readonly List<string> ingredients;
-
-            public AlchemyInfo(string id, JsonNode json)
-            {
-                this.id = id;
-                comment = json["comment"]?.GetValue<string>();
-                tier = (CharacterContent.Stats.Tier)System.Enum.Parse(typeof(CharacterContent.Stats.Tier), json["tier"].GetValue<string>());
-
-                ingredients = new();
-                JsonArray jsonArray = json["ingredients"].AsArray();
-                for(int i=0;i<jsonArray.Count;i++)
-                {
-                    ingredients.Add(jsonArray[i].GetValue<string>());
-                }
-            }
-        }
-
-        public class SkillInfo
-        {
-            public readonly string comment;
-            public readonly int row;    // gemparam row
-            public readonly CharacterContent.Stats.Tier tier;  // strength and rarity of skill
-            public readonly int value;  // value is how much merchants will sell it for
-
-            public readonly ItemText text;
-
-            public SkillInfo(JsonNode json)
-            {
-                comment = json["comment"]?.GetValue<string>();
-                row = json["row"].GetValue<int>();
-                tier = (CharacterContent.Stats.Tier)System.Enum.Parse(typeof(CharacterContent.Stats.Tier), json["tier"].GetValue<string>());
-                value = json["value"].GetValue<int>();
-
-                if (json["text"] != null)
-                {
-                    text = new();
-                    text.name = json["text"]["name"] != null ? json["text"]["name"].GetValue<string>() : null;
-                    text.summary = json["text"]["summary"] != null ? json["text"]["summary"].GetValue<string>() : null;
-                    text.description = json["text"]["description"] != null ? json["text"]["description"].GetValue<string>() : null;
-                }
-                else
-                {
-                    text = null;
-                }
-            }
-
             public bool HasTextChanges()
             {
                 return text != null && (text.name != null || text.summary != null || text.description != null || text.effect != null);
             }
         }
 
-        public class SpellRemap
+        public record SpellRemap(string id, string comment, int row, ItemText text)
         {
-            public readonly string id, comment;
-            public readonly int row;  // both the GoodsParam for the spell item and the MagicParam for the actual spell share the same row so we good
-
-            public readonly ItemText text;
-
-            public SpellRemap(string id, JsonNode json)
-            {
-                this.id = id;
-                row = json["row"].GetValue<int>();
-                comment = json["comment"]?.GetValue<string>();
-
-                if (json["text"] != null)
-                {
-                    text = new();
-                    text.name = json["text"]["name"] != null ? json["text"]["name"].GetValue<string>() : null;
-                    text.summary = json["text"]["summary"] != null ? json["text"]["summary"].GetValue<string>() : null;
-                    text.description = json["text"]["description"] != null ? json["text"]["description"].GetValue<string>() : null;
-                }
-                else
-                {
-                    text = null;
-                }
-            }
-
             public bool HasTextChanges()
             {
                 return text != null && (text.name != null || text.summary != null || text.description != null || text.effect != null);
             }
         }
 
-        public class ItemRemap
+        public record ItemRemap(string id, string comment, ItemManager.Type type, int row, ItemManager.Infusion infusion, ItemText text, int skill = -1, int upgrade = 0)
         {
-            public readonly string id, comment;
-            public readonly ItemManager.Type type;
-            public readonly int row;
-
-            // these 3 fields are only used for the CustomWeapon type
-            public readonly ItemManager.Infusion infusion;
-            public readonly int skill, upgrade;
-
-            public readonly ItemText text;
-
-            public ItemRemap(string id, JsonNode json)
-            {
-                this.id = id;
-                type = (ItemManager.Type)System.Enum.Parse(typeof(ItemManager.Type), json["type"].GetValue<string>());
-                row = json["row"].GetValue<int>();
-                comment = json["comment"]?.GetValue<string>();
-
-                if (json["infusion"] != null)
-                {
-                    infusion = (ItemManager.Infusion)System.Enum.Parse(typeof(ItemManager.Infusion), json["infusion"].GetValue<string>());
-                }
-                else
-                {
-                    infusion = ItemManager.Infusion.None;
-                }
-
-                skill = json["skill"] != null ? json["skill"].GetValue<int>() : -1;
-                upgrade = json["upgrade"] != null ? json["upgrade"].GetValue<int>() : 0;
-
-                if (json["text"] != null)
-                {
-                    text = new();
-                    text.name = json["text"]["name"] != null ? json["text"]["name"].GetValue<string>() : null;
-                    text.summary = json["text"]["summary"] != null ? json["text"]["summary"].GetValue<string>() : null;
-                    text.description = json["text"]["description"] != null ? json["text"]["description"].GetValue<string>() : null;
-                    text.effect = json["text"]["effect"] != null ? json["text"]["effect"].GetValue<string>() : null;
-                    text.enchant = json["text"]["enchant"] != null ? json["text"]["enchant"].AsArray().Select(node => node.GetValue<string>()).ToArray() : null;
-                }
-                else
-                {
-                    text = null;
-                }
-            }
-
             public bool HasTextChanges()
             {
                 return text != null && (text.name != null || text.summary != null || text.description != null || text.effect != null);
             }
         }
 
-        public class ItemText
-        {
-            public string name, summary, description, effect;
-            public string[] enchant;
+        public record ItemText(string name, string summary, string description, string effect, string[] enchant);
 
-            public ItemText() { }
+        public record SpeffDefinition(string comment, int row, Dictionary<string, string> data,
+                                        SpeffManager.Speff.Effect.MagicEffect icon = SpeffManager.Speff.Effect.MagicEffect.None)
+        {
+            public string id { get; set; }
         }
 
-        public class SpeffDefinition
+        public record ItemDefinition(string comment, ItemManager.Type type, int row, ItemManager.Infusion infusion,
+                                    ItemText text, Dictionary<string, string> data, int skill = -1, int upgrade = 0, bool useIcon = false)
         {
-            public readonly string id, comment;
-            public readonly int row;
-
-            public readonly SpeffManager.Speff.Effect.MagicEffect icon; // buff icon to use. 'None' is valid
-
-            public readonly Dictionary<string, string> data;
-
-            public SpeffDefinition(string jsonPath)
-            {
-                id = Path.GetFileNameWithoutExtension(jsonPath);
-
-                JsonNode json = JsonNode.Parse(File.ReadAllText(jsonPath));
-
-                comment = json["comment"]?.GetValue<string>();
-                row = json["row"].GetValue<int>();
-
-                if (json["icon"] != null && json["icon"].GetValue<string>().Trim().ToLower() != "none")
-                {
-                    icon = (SpeffManager.Speff.Effect.MagicEffect)System.Enum.Parse(typeof(SpeffManager.Speff.Effect.MagicEffect), json["icon"].GetValue<string>());
-                }
-                else
-                {
-                    icon = SpeffManager.Speff.Effect.MagicEffect.None;
-                }
-
-                data = new();
-                foreach (var property in json["data"].AsObject())
-                {
-                    data.Add(property.Key, property.Value.ToString());
-                }
-            }
+            public string id { get; set; }
         }
 
-        public class ItemDefinition
+        public record EnemyRemapData(int row, Dictionary<string, string> data)
         {
-            public readonly string id, comment;
-            public readonly ItemManager.Type type;
-            public readonly int row;                   // row we copy as our base
-
-            // these 3 fields are only used for the CustomWeapon type
-            public readonly ItemManager.Infusion infusion;
-            public readonly int skill, upgrade;
-
-            public readonly bool useIcon; // use morrowind item icon if true, otherwise use whatever is set in the param
-
-            public readonly ItemText text;
-            public readonly Dictionary<string, string> data;
-
-            public ItemDefinition(string jsonPath)
-            {
-                id = Path.GetFileNameWithoutExtension(jsonPath);
-
-                JsonNode json = JsonNode.Parse(File.ReadAllText(jsonPath));
-
-                comment = json["comment"]?.GetValue<string>();
-                type = Enum.Parse<ItemManager.Type>(json["type"].GetValue<string>());
-                row = json["row"].GetValue<int>();
-
-                if (json["infusion"] != null)
-                {
-                    infusion = Enum.Parse<ItemManager.Infusion>(json["infusion"].GetValue<string>());
-                }
-                else
-                {
-                    infusion = ItemManager.Infusion.None;
-                }
-
-                skill = json["skill"] != null ? json["skill"].GetValue<int>() : -1;
-                upgrade = json["upgrade"] != null ? json["upgrade"].GetValue<int>() : 0;
-
-                useIcon = json["useIcon"] != null ? json["useIcon"].GetValue<bool>() : false;
-
-                text = new();
-                text.name = json["text"]["name"] != null ? json["text"]["name"].GetValue<string>() : null;
-                text.summary = json["text"]["summary"] != null ? json["text"]["summary"].GetValue<string>() : null;
-                text.description = json["text"]["description"] != null ? json["text"]["description"].GetValue<string>() : null;
-                text.effect = json["text"]["effect"] != null ? json["text"]["effect"].GetValue<string>() : null;
-                text.enchant = json["text"]["enchant"] != null ? json["text"]["enchant"].AsArray().Select(node => node.GetValue<string>()).ToArray() : null;
-
-                data = new();
-                foreach(var property in json["data"].AsObject())
-                {
-                    data.Add(property.Key, property.Value.ToString());
-                }
-            }
+            public EnemyRemapData(int row)
+                : this(row, new())
+            {}
         }
 
-        public class EnemyRemap
+        public record EnemyRemap(string id, string comment, string character, EnemyRemapData npc, EnemyRemapData think)
         {
-            public readonly string id, comment, character;
-            public readonly EnemyRemapData npc, think;
-
-            public EnemyRemap(string id, JsonNode json)
-            {
-                this.id = id.ToLower().Trim();
-                character = json["character"]?.GetValue<string>();
-                comment = json["comment"]?.GetValue<string>();
-
-                npc = new(json["npc"]);
-                think = new(json["think"]);
-            }
-
             /* Default constructor, points to a Goat */
             public EnemyRemap()
-            {
-                id = "DEFAULT";
-                character = "c6060";
-                comment = "Default constructor, used when no remap found. Creates a goat.";
-
-                npc = new(60600010);
-                think = new(60600000);
-            }
-
-            public class EnemyRemapData
-            {
-                public readonly int row;
-                public readonly Dictionary<string, string> data;
-
-                public EnemyRemapData(JsonNode json)
-                {
-                    row = json["row"].GetValue<int>();
-
-                    data = new();
-                    foreach (var property in json["data"].AsObject())
-                    {
-                        data.Add(property.Key, property.Value.ToString());
-                    }
-                }
-
-                public EnemyRemapData(int row)
-                {
-                    this.row = row;
-                    data = new();
-                }
-            }
+                : this("DEFAULT", "Default constructor, used when no remap found. Creates a goat.", "c6060", new(60600010), new(60600000))
+            {}
         }
 
-        public class FaceData
+        public record FaceData(Dictionary<string, byte> data)
         {
-            public readonly string id;
-            public readonly Dictionary<string, byte> data;
-
-            public FaceData(string id, JsonNode json)
-            {
-                this.id = id.ToLower().Trim();
-
-                data = new();
-                foreach (var property in json.AsObject())
-                {
-                    data.Add(property.Key, property.Value.GetValue<byte>());
-                }
-            }
+            public string id { get; set; }
         }
 
         public record Hair(byte part, Hair.Color color)
@@ -701,15 +333,6 @@ namespace JortPob
             }
         }
 
-        public class LoadingTip
-        {
-            public readonly string title, text;
-
-            public LoadingTip(string title, string text)
-            {
-                this.title = title;
-                this.text = text;
-            }
-        }
+        public record LoadingTip(string title, string text);
     }
 }

--- a/JortPob/Resources/overrides/alchemy.json
+++ b/JortPob/Resources/overrides/alchemy.json
@@ -1,54 +1,62 @@
-{
-  "p_restore_health_b": {
+[
+  {
+    "id": "p_restore_health_b",
     "comment": "Bargain Restore Health Potion Recipe",
     "tier": "Novice",
     "ingredients": [ "ingred_saltrice_01", "ingred_marshmerrow_01" ]
   },
-  "p_restore_health_c": {
+  {
+    "id": "p_restore_health_c",
     "comment": "Cheap Restore Health Potion Recipe",
     "tier": "Apprentice",
     "ingredients": [ "ingred_marshmerrow_01", "ingred_corkbulb_root_01" ]
   },
-  "p_restore_health_s": {
+  {
+    "id": "p_restore_health_s",
     "comment": "Standard Restore Health Potion Recipe",
     "tier": "Journeyman",
     "ingredients": [ "ingred_wickwheat_01", "ingred_saltrice_01" ]
   },
-  "p_restore_health_q": {
+  {
+    "id": "p_restore_health_q",
     "comment": "Quality Restore Health Potion Recipe",
     "tier": "Expert",
     "ingredients": [ "ingred_marshmerrow_01", "ingred_resin_01" ]
   },
-  "p_restore_health_e": {
+  {
+    "id": "p_restore_health_e",
     "comment": "Exclusive Restore Health Potion Recipe",
     "tier": "Master",
     "ingredients": [ "ingred_corkbulb_root_01", "ingred_emerald_01" ]
   },
-
-
-  "p_restore_magicka_b": {
+  {
+    "id": "p_restore_magicka_b",
     "comment": "Bargain Restore Magicka Potion Recipe",
     "tier": "Novice",
     "ingredients": [ "ingred_heather_01", "ingred_comberry_01" ]
   },
-  "p_restore_magicka_c": {
+  {
+    "id": "p_restore_magicka_c",
     "comment": "Cheap Restore Magicka Potion Recipe",
     "tier": "Apprentice",
     "ingredients": [ "ingred_russula_01", "ingred_stoneflower_petals_01" ]
   },
-  "p_restore_magicka_s": {
+  {
+    "id": "p_restore_magicka_s",
     "comment": "Standard Restore Magicka Potion Recipe",
     "tier": "Journeyman",
     "ingredients": [ "ingred_bc_coda_flower", "ingred_frost_salts_01" ]
   },
-  "p_restore_magicka_q": {
+  {
+    "id": "p_restore_magicka_q",
     "comment": "Quality Restore Magicka Potion Recipe",
     "tier": "Expert",
     "ingredients": [ "ingred_stoneflower_petals_01", "ingred_void_salts_01" ]
   },
-  "p_restore_magicka_e": {
+  {
+    "id": "p_restore_magicka_e",
     "comment": "Exclusive Restore Magicka Potion Recipe",
     "tier": "Master",
     "ingredients": [ "ingred_willow_anther_01", "ingred_daedras_heart_01" ]
   }
-}
+]

--- a/JortPob/Resources/overrides/enemy_remap.json
+++ b/JortPob/Resources/overrides/enemy_remap.json
@@ -1,5 +1,6 @@
-{
-  "Rat": {
+[
+  {
+    "id": "Rat",
     "character": "c4080",
     "npc": {
       "row": 40800010,
@@ -11,8 +12,8 @@
     },
     "comment": "Regular size normal rat"
   },
-
-  "rat_blighted": {
+  {
+    "id": "rat_blighted",
     "character": "c4080",
     "npc": {
       "row": 40800010,
@@ -24,8 +25,8 @@
     },
     "comment": "Regular size normal rat"
   },
-
-  "rat_diseased": {
+  {
+    "id": "rat_diseased",
     "character": "c4080",
     "npc": {
       "row": 40800010,
@@ -37,8 +38,8 @@
     },
     "comment": "Regular size normal rat"
   },
-
-  "rat_cave_fgrh": {
+  {
+    "id": "rat_cave_fgrh",
     "character": "c4080",
     "npc": {
       "row": 40800010,
@@ -50,8 +51,8 @@
     },
     "comment": "Regular size normal rat"
   },
-
-  "rat_cave_fgt": {
+  {
+    "id": "rat_cave_fgt",
     "character": "c4080",
     "npc": {
       "row": 40800010,
@@ -63,8 +64,8 @@
     },
     "comment": "Regular size normal rat"
   },
-
-  "kwama worker": {
+  {
+    "id": "kwama worker",
     "character": "c4140",
     "npc": {
       "row": 41404020,
@@ -76,8 +77,8 @@
     },
     "comment": "Kwama worker to crystal snaily boy"
   },
-
-  "kwama worker entrance": {
+  {
+    "id": "kwama worker entrance",
     "character": "c4140",
     "npc": {
       "row": 41404020,
@@ -89,8 +90,8 @@
     },
     "comment": "Kwama worker to crystal snaily boy"
   },
-
-  "Kwama Queen": {
+  {
+    "id": "Kwama Queen",
     "character": "c4280",
     "npc": {
       "row": 42800060,
@@ -102,8 +103,8 @@
     },
     "comment": "Kwama queen to big ant"
   },
-
-  "mudcrab": {
+  {
+    "id": "mudcrab",
     "character": "c2271",
     "npc": {
       "row": 22710010,
@@ -115,8 +116,8 @@
     },
     "comment": "Small crab"
   },
-
-  "mudcrab-Diseased": {
+  {
+    "id": "mudcrab-Diseased",
     "character": "c2271",
     "npc": {
       "row": 22710010,
@@ -128,8 +129,8 @@
     },
     "comment": "Small crab"
   },
-
-  "scrib": {
+  {
+    "id": "scrib",
     "character": "c5490",
     "npc": {
       "row": 54900080,
@@ -141,8 +142,8 @@
     },
     "comment": "Springhare"
   },
-
-  "scrib blighted": {
+  {
+    "id": "scrib blighted",
     "character": "c5490",
     "npc": {
       "row": 54900080,
@@ -154,8 +155,8 @@
     },
     "comment": "Springhare"
   },
-
-  "scrib diseased": {
+  {
+    "id": "scrib diseased",
     "character": "c5490",
     "npc": {
       "row": 54900080,
@@ -167,8 +168,8 @@
     },
     "comment": "Springhare"
   },
-
-  "kwama forager": {
+  {
+    "id": "kwama forager",
     "character": "c4040",
     "npc": {
       "row": 40400031,
@@ -180,8 +181,8 @@
     },
     "comment": "Regular slug enemy"
   },
-
-  "kwama forager blighted": {
+  {
+    "id": "kwama forager blighted",
     "character": "c4040",
     "npc": {
       "row": 40400031,
@@ -193,8 +194,8 @@
     },
     "comment": "Regular slug enemy"
   },
-
-  "cliff racer": {
+  {
+    "id": "cliff racer",
     "character": "c4210",
     "npc": {
       "row": 42101114,
@@ -210,8 +211,8 @@
     },
     "comment": "Warhawk to CliffRacer"
   },
-
-  "cliff racer_blighted": {
+  {
+    "id": "cliff racer_blighted",
     "character": "c4210",
     "npc": {
       "row": 42101114,
@@ -227,8 +228,8 @@
     },
     "comment": "Warhawk to CliffRacer"
   },
-
-  "cliff racer_diseased": {
+  {
+    "id": "cliff racer_diseased",
     "character": "c4210",
     "npc": {
       "row": 42101114,
@@ -244,8 +245,8 @@
     },
     "comment": "Warhawk to CliffRacer"
   },
-
-  "netch_bull": {
+  {
+    "id": "netch_bull",
     "character": "c4180",
     "npc": {
       "row": 41800010,
@@ -257,8 +258,8 @@
     },
     "comment": "Spirit Jellyfish"
   },
-
-  "netch_betty": {
+  {
+    "id": "netch_betty",
     "character": "c4180",
     "npc": {
       "row": 41800010,
@@ -270,8 +271,8 @@
     },
     "comment": "Spirit Jellyfish"
   },
-
-  "slaughterfish": {
+  {
+    "id": "slaughterfish",
     "character": "c4440",
     "npc": {
       "row": 44400010,
@@ -283,8 +284,8 @@
     },
     "comment": "Spirit Jellyfish"
   },
-
-  "skeleton": {
+  {
+    "id": "skeleton",
     "character": "c3510",
     "npc": {
       "row": 35101012,
@@ -296,8 +297,8 @@
     },
     "comment": "Skeleton with sword"
   },
-
-  "skeleton archer": {
+  {
+    "id": "skeleton archer",
     "character": "c3510",
     "npc": {
       "row": 35102012,
@@ -309,8 +310,8 @@
     },
     "comment": "Skeleton with bow"
   },
-
-  "skeleton warrior": {
+  {
+    "id": "skeleton warrior",
     "character": "c3510",
     "npc": {
       "row": 35100012,
@@ -322,8 +323,8 @@
     },
     "comment": "Skeleton with sword and shield"
   },
-
-  "skeleton champion": {
+  {
+    "id": "skeleton champion",
     "character": "c3510",
     "npc": {
       "row": 35100012,
@@ -335,8 +336,8 @@
     },
     "comment": "Skeleton with sword and shield"
   },
-
-  "skeleton entrance": {
+  {
+    "id": "skeleton entrance",
     "character": "c3510",
     "npc": {
       "row": 35103012,
@@ -348,8 +349,8 @@
     },
     "comment": "Skeleton no weapon with firebombs"
   },
-
-  "skeleton_weak": {
+  {
+    "id": "skeleton_weak",
     "character": "c3510",
     "npc": {
       "row": 35103012,
@@ -361,8 +362,8 @@
     },
     "comment": "Skeleton no weapon with firebombs"
   },
-
-  "bonewalker_weak": {
+  {
+    "id": "bonewalker_weak",
     "character": "c3661",
     "npc": {
       "row": 36611031,
@@ -374,8 +375,8 @@
     },
     "comment": "Putrid corpse (poison) (small)"
   },
-
-  "bonewalker": {
+  {
+    "id": "bonewalker",
     "character": "c3661",
     "npc": {
       "row": 36611031,
@@ -387,8 +388,8 @@
     },
     "comment": "Putrid corpse (poison) (small)"
   },
-
-  "Bonewalker_Greater": {
+  {
+    "id": "Bonewalker_Greater",
     "character": "c3662",
     "npc": {
       "row": 36621031,
@@ -400,8 +401,8 @@
     },
     "comment": "Putrid corpse (poison) (large)"
   },
-
-  "bonelord": {
+  {
+    "id": "bonelord",
     "character": "c3500",
     "npc": {
       "row": 35002020,
@@ -413,8 +414,8 @@
     },
     "comment": "Large skeleton (Scythe)"
   },
-
-  "ancestor_ghost": {
+  {
+    "id": "ancestor_ghost",
     "character": "c4315",
     "npc": {
       "row": 43150012,
@@ -426,8 +427,8 @@
     },
     "comment": "Mauseleum soldier ghosts boys"
   },
-
-  "scamp_creeper": {
+  {
+    "id": "scamp_creeper",
     "character": "c4100",
     "npc": {
       "row": 41002010,
@@ -439,8 +440,8 @@
     },
     "comment": "Basic Demi-human with Club"
   },
-
-  "vivec_god": {
+  {
+    "id": "vivec_god",
     "character": "c5130",
     "npc": {
       "row": 51301099,
@@ -452,4 +453,4 @@
     },
     "comment": "Messmer"
   }
-}
+]

--- a/JortPob/Resources/overrides/items/remap/accessories.json
+++ b/JortPob/Resources/overrides/items/remap/accessories.json
@@ -1,7 +1,8 @@
-{
-  "nuccius_ring": {
+[
+  {
+    "id": "nuccius_ring",
     "type": "Accessory",
     "row": 1020,
     "comment": "Vondius's cursed ring to Viridian Amber Medalion"
   }
-}
+]

--- a/JortPob/Resources/overrides/items/remap/armor.json
+++ b/JortPob/Resources/overrides/items/remap/armor.json
@@ -1,619 +1,742 @@
-{
-    "steel_helm": {
-        "type": "Armor",
-        "row": 790000,
-        "comment": "Bloodhound Knight Helm"
-    },
-  "steel_cuirass": {
+[
+  {
+    "id": "steel_helm",
+    "type": "Armor",
+    "row": 790000,
+    "comment": "Bloodhound Knight Helm"
+  },
+  {
+    "id": "steel_cuirass",
     "type": "Armor",
     "row": 5130100,
     "comment": "Bloodhound Knight Armor"
   },
-    "steel_gauntlet_left": {
-        "type": "Armor",
-        "row": 790200,
-        "comment": "Bloodhound Knight Gauntlets"
-    },
-    "steel_greaves": {
-        "type": "Armor",
-        "row": 790300,
-        "comment": "Bloodhound Knight Greaves"
-    },
-    "bonemold_greaves": {
-        "type": "Armor",
-        "row": 690300,
-        "comment": "Royal Remains Greaves"
-    },
-    "bonemold_cuirass": {
-        "type": "Armor",
-        "row": 690100,
-        "comment": "Royal Remains Armor"
-    },
-    "bonemold_bracer_left": {
-        "type": "Armor",
-        "row": 690200,
-        "comment": "Royal Remains Gauntlets"
-    },
-    "bonemold_helm": {
-        "type": "Armor",
-        "row": 690000,
-        "comment": "Royal Remains Helmet"
-    },
-    "bonemold_armun-an_cuirass": {
-        "type": "Armor",
-        "row": 5200100,
-        "comment": "Death Knight Armor"
-    },
-    "bonemold_armun-an_helm": {
-        "type": "Armor",
-        "row": 5200000,
-        "comment": "Death Knight Helm"
-    },
-    "bonemold_gah-julan_cuirass": {
-        "type": "Armor",
-        "row": 5230100,
-        "comment": "Gravebird's Blackquill Armor"
-    },
-    "bonemold_gah-julan_helm": {
-        "type": "Armor",
-        "row": 5230000,
-        "comment": "Gravebird Helm"
-    },
-    "iron_greaves": {
-        "type": "Armor",
-        "row": 1500300,
-        "comment": "Knight Greaves"
-    },
-    "iron_cuirass": {
-        "type": "Armor",
-        "row": 660100,
-        "comment": "Vagabond Knight Armor"
-    },
-    "iron_gauntlet_left": {
-        "type": "Armor",
-        "row": 1500200,
-        "comment": "Knight Gauntlets"
-    },
-    "iron_helmet": {
-        "type": "Armor",
-        "row": 1101000,
-        "comment": "Greathelm"
-    },
-    "glass_greaves": {
-        "type": "Armor",
-        "row": 170300,
-        "comment": "Blaidd's Greaves"
-    },
-    "glass_cuirass": {
-        "type": "Armor",
-        "row": 171100,
-        "comment": "Blaidd's Armor (Altered)"
-    },
-    "glass_bracer_left": {
-        "type": "Armor",
-        "row": 350200,
-        "comment": "Fire Monk Gauntlets"
-    },
-    "glass_helm": {
-        "type": "Armor",
-        "row": 1300000,
-        "comment": "Nox Mirrorhelm"
-    },
-    "chitin greaves": {
-        "type": "Armor",
-        "row": 80300,
-        "comment": "Scaled Greaves"
-    },
-    "chitin cuirass": {
-        "type": "Armor",
-        "row": 81100,
-        "comment": "Scaled Armor (Altered)"
-    },
-    "chitin guantlet - left": {
-        "type": "Armor",
-        "row": 80200,
-        "comment": "Scaled Gauntlets"
-    },
-    "chitin helm": {
-        "type": "Armor",
-        "row": 80000,
-        "comment": "Scaled Helm"
-    },
-    "daedric_greaves": {
-        "type": "Armor",
-        "row": 5090300,
-        "comment": "Greaves of Night"
-    },
-    "daedric_cuirass": {
-        "type": "Armor",
-        "row": 5090100,
-        "comment": "Armor of Night"
-    },
-    "daedric_gauntlet_left": {
-        "type": "Armor",
-        "row": 5090200,
-        "comment": "Gauntlets of Night"
-    },
-    "daedric_fountain_helm": {
-        "type": "Armor",
-        "row": 230000,
-        "comment": "Night's Cavalry Helm"
-    },
-    "daedric_god_helm": {
-        "type": "Armor",
-        "row": 231000,
-        "comment": "Night's Cavalry Helm (Altered)"
-    },
-    "daedric_terrifying_helm": {
-        "type": "Armor",
-        "row": 5090000,
-        "comment": "Helm of Night"
-    },
-    "dwemer_greaves": {
-        "type": "Armor",
-        "row": 270300,
-        "comment": "Tree Sentinel Greaves"
-    },
-    "dwemer_cuirass": {
-        "type": "Armor",
-        "row": 271100,
-        "comment": "Tree Sentinel Armor (Altered)"
-    },
-    "dwemer_bracer_left": {
-        "type": "Armor",
-        "row": 270200,
-        "comment": "Tree Sentinel Gauntlets"
-    },
-    "dwemer_helm": {
-        "type": "Armor",
-        "row": 140000,
-        "comment": "Bull-Goat Helm"
-    },
-    "ebony_greaves": {
-        "type": "Armor",
-        "row": 760300,
-        "comment": "Maliketh's Greaves"
-    },
-    "ebony_cuirass": {
-        "type": "Armor",
-        "row": 761100,
-        "comment": "Maliketh's Armor (Altered)"
-    },
-    "ebony_bracer_left": {
-        "type": "Armor",
-        "row": 760200,
-        "comment": "Maliketh's Gauntlets"
-    },
-    "ebony_closed_helm": {
-        "type": "Armor",
-        "row": 760000,
-        "comment": "Maliketh's Helm"
-    },
-    "orcish_greaves": {
-        "type": "Armor",
-        "row": 5160300,
-        "comment": "Rakshasa Greaves"
-    },
-    "orcish_cuirass": {
-        "type": "Armor",
-        "row": 5160100,
-        "comment": "Rakshasa Armor"
-    },
-    "orcish_bracer_left": {
-        "type": "Armor",
-        "row": 5160200,
-        "comment": "Rakshasa Gauntlets"
-    },
-    "orcish_helm": {
-        "type": "Armor",
-        "row": 5160000,
-        "comment": "Rakshasa Helm"
-    },
-    "fur_greaves": {
-        "type": "Armor",
-        "row": 530300,
-        "comment": "Godskin Noble Trousers"
-    },
-    "fur_cuirass": {
-        "type": "Armor",
-        "row": 420100,
-        "comment": "Vulgar Militia Armor"
-    },
-    "fur_gauntlet_left": {
-        "type": "Armor",
-        "row": 540200,
-        "comment": "Depraved Perfumer Gloves"
-    },
-    "fur_helm": {
-        "type": "Armor",
-        "row": 1980000,
-        "comment": "Highwayman Hood"
-    },
-    "imperial_greaves": {
-        "type": "Armor",
-        "row": 1710300,
-        "comment": "Raya Lucarian Greaves"
-    },
-    "imperial cuirass_armor": {
-        "type": "Armor",
-        "row": 1761100,
-        "comment": "Gelmir Knight Armor (Altered)"
-    },
-    "imperial left gauntlet": {
-        "type": "Armor",
-        "row": 420200,
-        "comment": "Vulgar Militia Gauntlets"
-    },
-    "imperial helmet armor": {
-        "type": "Armor",
-        "row": 1730000,
-        "comment": "Radahn Soldier Helm"
-    },
-    "netch_leather_greaves": {
-        "type": "Armor",
-        "row": 1400300,
-        "comment": "Leather Boots"
-    },
-    "netch_leather_cuirass": {
-        "type": "Armor",
-        "row": 931100,
-        "comment": "Bandit Garb"
-    },
-    "netch_leather_gauntlet_left": {
-        "type": "Armor",
-        "row": 1400200,
-        "comment": "Leather Gloves"
-    },
-    "netch_leather_helm": {
-        "type": "Armor",
-        "row": 540000,
-        "comment": "Depraved Perfumer Headscarf"
-    },
-    "netch_leather_boiled_cuirass": {
-        "type": "Armor",
-        "row": 1400100,
-        "comment": "Leather Armor"
-    },
-    "netch_leather_boiled_helm": {
-        "type": "Armor",
-        "row": 420000,
-        "comment": "Vulgar Militia Helm"
-    },
-    "bloodworm_helm_unique": {
-        "type": "Armor",
-        "row": 5182000,
-        "comment": "Death Mask Helm"
-    },
-    "bonemold_chuzei_helm": {
-        "type": "Armor",
-        "row": 5253000,
-        "comment": "Divine Bird Helm"
-    },
-    "bonemold_founders_helm": {
-        "type": "Armor",
-        "row": 570000,
-        "comment": "Crucible Axe Helm"
-    },
-    "bonedancer gauntlet": {
-        "type": "Armor",
-        "row": 5080200,
-        "comment": "Dancer's Bracer"
-    },
-    "boneweave gauntlet": {
-        "type": "Armor",
-        "row": 5230200,
-        "comment": "Gravebird Bracelets"
-    },
-    "cephalopod_helm": {
-        "type": "Armor",
-        "row": 1110000,
-        "comment": "Octopus Head"
-    },
-    "chest of fire": {
-        "type": "Armor",
-        "row": 5180100,
-        "comment": "Fire Knight Armor"
-    },
-    "chitin_mask_helm": {
-        "type": "Armor",
-        "row": 5210000,
-        "comment": "Curseblade Mask"
-    },
-    "chitin_watchman_helm": {
-        "type": "Armor",
-        "row": 330000,
-        "comment": "Guardian Mask"
-    },
-    "cloth bracer left": {
-        "type": "Armor",
-        "row": 5070200,
-        "comment": "Braided Arm Wraps"
-    },
-    "demon cephalopod": {
-        "type": "Armor",
-        "row": 5290000,
-        "comment": "Divine Beast Head"
-    },
-    "demon helm": {
-        "type": "Armor",
-        "row": 5210000,
-        "comment": "Curseblade Mask"
-    },
-    "demon mole crab": {
-        "type": "Armor",
-        "row": 5330000,
-        "comment": "Imp Head (Lion)"
-    },
-    "devil cephalopod helm": {
-        "type": "Armor",
-        "row": 1090000,
-        "comment": "Silver Tear Mask"
-    },
-    "devil helm": {
-        "type": "Armor",
-        "row": 1890000,
-        "comment": "Omensmirk Mask"
-    },
-    "devil mole crab helm": {
-        "type": "Armor",
-        "row": 5320000,
-        "comment": "Greatjar"
-    },
-    "dragonscale_cuirass": {
-        "type": "Armor",
-        "row": 61100,
-        "comment": "Drake Knight Armor (Altered)"
-    },
-    "dragonscale_helm": {
-        "type": "Armor",
-        "row": 60000,
-        "comment": "Drake Knight Helm"
-    },
-    "dreugh_cuirass": {
-        "type": "Armor",
-        "row": 40100,
-        "comment": "Scale Armor"
-    },
-    "dreugh_helm": {
-        "type": "Armor",
-        "row": 970000,
-        "comment": "Omen Helm"
-    },
-    "dust_adept_helm": {
-        "type": "Armor",
-        "row": 5060000,
-        "comment": "High Priest Hat"
-    },
-    "ebony_closed_helm_fghl": {
-        "type": "Armor",
-        "row": 680000,
-        "comment": "White Mask"
-    },
-    "fiend helm": {
-        "type": "Armor",
-        "row": 5210000,
-        "comment": "Curseblade Mask"
-    },
-    "fur_bearskin_cuirass": {
-        "type": "Armor",
-        "row": 5020100,
-        "comment": "Iron Rivet Armor"
-    },
-    "fur_colovian_helm": {
-        "type": "Armor",
-        "row": 5020000,
-        "comment": "Pelt of Ralva"
-    },
-    "gauntlet_fists_l_unique": {
-        "type": "Armor",
-        "row": 5270200,
-        "comment": "Young Lion's Gauntlets"
-    },
-    "gauntlet_horny_fist_l": {
-        "type": "Armor",
-        "row": 5250200,
-        "comment": "Horned Warrior Gauntlets"
-    },
-    "gondolier_helm": {
-        "type": "Armor",
-        "row": 250000,
-        "comment": "Nomadic Merchant's Chapeau"
-    },
-    "heart wall": {
-        "type": "Armor",
-        "row": 5200100,
-        "comment": "Death Knight Armor"
-    },
-    "helm of holy fire": {
-        "type": "Armor",
-        "row": 5180000,
-        "comment": "Fire Knight Helm"
-    },
-    "helm of wounding": {
-        "type": "Armor",
-        "row": 210000,
-        "comment": "Briar Helm"
-    },
-    "icecap_unique": {
-        "type": "Armor",
-        "row": 1010000,
-        "comment": "Snow Witch Hat"
-    },
-    "imperial helmet armor_Dae_curse": {
-        "type": "Armor",
-        "row": 5140000,
-        "comment": "Messmer Soldier Helm"
-    },
-    "imperial_chain_coif_helm": {
-        "type": "Armor",
-        "row": 1100000,
-        "comment": "Chain Coif"
-    },
-    "imperial_chain_cuirass": {
-        "type": "Armor",
-        "row": 1100100,
-        "comment": "Chain Armor"
-    },
-    "imperial_chain_greaves": {
-        "type": "Armor",
-        "row": 1100300,
-        "comment": "Chain Leggings"
-    },
-    "imperial_studded_cuirass": {
-        "type": "Armor",
-        "row": 190100,
-        "comment": "Exile Armor"
-    },
-    "indoril cuirass": {
-        "type": "Armor",
-        "row": 340100,
-        "comment": "Cleanrot Armor"
-    },
-    "indoril helmet": {
-        "type": "Armor",
-        "row": 340000,
-        "comment": "Cleanrot Helm"
-    },
-    "indoril left gauntlet": {
-        "type": "Armor",
-        "row": 340200,
-        "comment": "Cleanrot Gauntlets"
-    },
-    "left cloth horny fist bracer": {
-        "type": "Armor",
-        "row": 5070200,
-        "comment": "Braided Arm Wraps"
-    },
-    "left gauntlet of the horny fist": {
-        "type": "Armor",
-    	"row": 360200,
-	    "comment": "Fire Prelate Gauntlets"
-    },
-    "left leather bracer": {
-        "type": "Armor",
-        "row": 5190200,
-        "comment": "Leather Arm Wraps"
-    },
-    "left_horny_fist_gauntlet": {
-        "type": "Armor",
-        "row": 5250200,
-        "comment": "Horned Warrior Gauntlets"
-    },
-    "merisan helm": {
-        "type": "Armor",
-        "row": 380000,
-        "comment": "Aristocrat Hat"
-    },
-    "merisan_cuirass": {
-        "type": "Armor",
-        "row": 380100,
-        "comment": "Aristocrat Coat"
-    },
-    "mole_crab_helm": {
-        "type": "Armor",
-        "row": 5320000,
-        "comment": "Greatjar"
-    },
-    "morag_tong_helm": {
-        "type": "Armor",
-        "row": 5280000,
-        "comment": "Shadow Militiaman Helm"
-    },
-    "Mountain Spirit": {
-        "type": "Armor",
-	    "row": 1070100,
-    	"useIcon": true,
-	    "comment": "Zamor Armor"
-    },
-    "newtscale_cuirass": {
-        "type": "Armor",
-        "row": 670100,
-        "useIcon": true,
-        "comment": "Blue Cloth Vest"
-    },
-    "nordic_iron_cuirass": {
-        "type": "Armor",
-        "row": 5020100,
-        "comment": "Iron Rivet Armor"
-    },
-    "nordic_iron_helm": {
-        "type": "Armor",
-        "row": 5021000,
-        "comment": "Fang Helm"
-    },
-    "nordic_ringmail_cuirass": {
-        "type": "Armor",
-        "row": 1101100,
-        "comment": "Eye Surcoat"
-    },
-    "redoran_master_helm": {
-        "type": "Armor",
-        "row": 571000,
-        "comment": "Crucible Tree Helm"
-    },
-    "silver_cuirass": {
-        "type": "Armor",
-        "row": 5260100,
-        "comment": "Rellana's Armor"
-    },
-    "silver_dukesguard_cuirass": {
-        "type": "Armor",
-        "row": 5002100,
-        "comment": "Oathseeker Knight Armor"
-    },
-    "silver_helm": {
-        "type": "Armor",
-        "row": 5260000,
-        "comment": "Rellana's Helm"
-    },
-    "slave_bracer_left": {
-        "type": "Armor",
-        "row": 5210200,
-        "comment": "Ascetic's Wrist Guards"
-    },
-    "storm helm": {
-        "type": "Armor",
-        "row": 240000,
-        "comment": "Blue Silver Mail Hood"
-    },
-    "templar bracer left": {
-        "type": "Armor",
-        "row": 5150200,
-        "comment": "Black Knight Gauntlets"
-    },
-    "templar_cuirass": {
-        "type": "Armor",
-        "row": 5150100,
-        "comment": "Black Knight Armor"
-    },
-    "templar_greaves": {
-        "type": "Armor",
-        "row": 5150300,
-        "comment": "Black Knight Greaves"
-    },
-    "templar_helmet_armor": {
-        "type": "Armor",
-        "row": 5150000,
-        "comment": "Black Knight Helm"
-    },
-    "the_chiding_cuirass": {
-        "type": "Armor",
-        "row": 5070100,
-        "comment": "Braided Cord Robe"
-    },
-    "trollbone_cuirass": {
-        "type": "Armor",
-        "row": 301100,
-        "comment": "Shaman Furs"
-    },
-    "trollbone_helm": {
-        "type": "Armor",
-        "row": 301000,
-        "comment": "Shining Horned Headband"
-    },
-    "velothian_helm": {
-        "type": "Armor",
-        "row": 1040000,
-        "comment": "Radiant Gold Mask"
-    }
-}
+  {
+    "id": "steel_gauntlet_left",
+    "type": "Armor",
+    "row": 790200,
+    "comment": "Bloodhound Knight Gauntlets"
+  },
+  {
+    "id": "steel_greaves",
+    "type": "Armor",
+    "row": 790300,
+    "comment": "Bloodhound Knight Greaves"
+  },
+  {
+    "id": "bonemold_greaves",
+    "type": "Armor",
+    "row": 690300,
+    "comment": "Royal Remains Greaves"
+  },
+  {
+    "id": "bonemold_cuirass",
+    "type": "Armor",
+    "row": 690100,
+    "comment": "Royal Remains Armor"
+  },
+  {
+    "id": "bonemold_bracer_left",
+    "type": "Armor",
+    "row": 690200,
+    "comment": "Royal Remains Gauntlets"
+  },
+  {
+    "id": "bonemold_helm",
+    "type": "Armor",
+    "row": 690000,
+    "comment": "Royal Remains Helmet"
+  },
+  {
+    "id": "bonemold_armun-an_cuirass",
+    "type": "Armor",
+    "row": 5200100,
+    "comment": "Death Knight Armor"
+  },
+  {
+    "id": "bonemold_armun-an_helm",
+    "type": "Armor",
+    "row": 5200000,
+    "comment": "Death Knight Helm"
+  },
+  {
+    "id": "bonemold_gah-julan_cuirass",
+    "type": "Armor",
+    "row": 5230100,
+    "comment": "Gravebird's Blackquill Armor"
+  },
+  {
+    "id": "bonemold_gah-julan_helm",
+    "type": "Armor",
+    "row": 5230000,
+    "comment": "Gravebird Helm"
+  },
+  {
+    "id": "iron_greaves",
+    "type": "Armor",
+    "row": 1500300,
+    "comment": "Knight Greaves"
+  },
+  {
+    "id": "iron_cuirass",
+    "type": "Armor",
+    "row": 660100,
+    "comment": "Vagabond Knight Armor"
+  },
+  {
+    "id": "iron_gauntlet_left",
+    "type": "Armor",
+    "row": 1500200,
+    "comment": "Knight Gauntlets"
+  },
+  {
+    "id": "iron_helmet",
+    "type": "Armor",
+    "row": 1101000,
+    "comment": "Greathelm"
+  },
+  {
+    "id": "glass_greaves",
+    "type": "Armor",
+    "row": 170300,
+    "comment": "Blaidd's Greaves"
+  },
+  {
+    "id": "glass_cuirass",
+    "type": "Armor",
+    "row": 171100,
+    "comment": "Blaidd's Armor (Altered)"
+  },
+  {
+    "id": "glass_bracer_left",
+    "type": "Armor",
+    "row": 350200,
+    "comment": "Fire Monk Gauntlets"
+  },
+  {
+    "id": "glass_helm",
+    "type": "Armor",
+    "row": 1300000,
+    "comment": "Nox Mirrorhelm"
+  },
+  {
+    "id": "chitin greaves",
+    "type": "Armor",
+    "row": 80300,
+    "comment": "Scaled Greaves"
+  },
+  {
+    "id": "chitin cuirass",
+    "type": "Armor",
+    "row": 81100,
+    "comment": "Scaled Armor (Altered)"
+  },
+  {
+    "id": "chitin guantlet - left",
+    "type": "Armor",
+    "row": 80200,
+    "comment": "Scaled Gauntlets"
+  },
+  {
+    "id": "chitin helm",
+    "type": "Armor",
+    "row": 80000,
+    "comment": "Scaled Helm"
+  },
+  {
+    "id": "daedric_greaves",
+    "type": "Armor",
+    "row": 5090300,
+    "comment": "Greaves of Night"
+  },
+  {
+    "id": "daedric_cuirass",
+    "type": "Armor",
+    "row": 5090100,
+    "comment": "Armor of Night"
+  },
+  {
+    "id": "daedric_gauntlet_left",
+    "type": "Armor",
+    "row": 5090200,
+    "comment": "Gauntlets of Night"
+  },
+  {
+    "id": "daedric_fountain_helm",
+    "type": "Armor",
+    "row": 230000,
+    "comment": "Night's Cavalry Helm"
+  },
+  {
+    "id": "daedric_god_helm",
+    "type": "Armor",
+    "row": 231000,
+    "comment": "Night's Cavalry Helm (Altered)"
+  },
+  {
+    "id": "daedric_terrifying_helm",
+    "type": "Armor",
+    "row": 5090000,
+    "comment": "Helm of Night"
+  },
+  {
+    "id": "dwemer_greaves",
+    "type": "Armor",
+    "row": 270300,
+    "comment": "Tree Sentinel Greaves"
+  },
+  {
+    "id": "dwemer_cuirass",
+    "type": "Armor",
+    "row": 271100,
+    "comment": "Tree Sentinel Armor (Altered)"
+  },
+  {
+    "id": "dwemer_bracer_left",
+    "type": "Armor",
+    "row": 270200,
+    "comment": "Tree Sentinel Gauntlets"
+  },
+  {
+    "id": "dwemer_helm",
+    "type": "Armor",
+    "row": 140000,
+    "comment": "Bull-Goat Helm"
+  },
+  {
+    "id": "ebony_greaves",
+    "type": "Armor",
+    "row": 760300,
+    "comment": "Maliketh's Greaves"
+  },
+  {
+    "id": "ebony_cuirass",
+    "type": "Armor",
+    "row": 761100,
+    "comment": "Maliketh's Armor (Altered)"
+  },
+  {
+    "id": "ebony_bracer_left",
+    "type": "Armor",
+    "row": 760200,
+    "comment": "Maliketh's Gauntlets"
+  },
+  {
+    "id": "ebony_closed_helm",
+    "type": "Armor",
+    "row": 760000,
+    "comment": "Maliketh's Helm"
+  },
+  {
+    "id": "orcish_greaves",
+    "type": "Armor",
+    "row": 5160300,
+    "comment": "Rakshasa Greaves"
+  },
+  {
+    "id": "orcish_cuirass",
+    "type": "Armor",
+    "row": 5160100,
+    "comment": "Rakshasa Armor"
+  },
+  {
+    "id": "orcish_bracer_left",
+    "type": "Armor",
+    "row": 5160200,
+    "comment": "Rakshasa Gauntlets"
+  },
+  {
+    "id": "orcish_helm",
+    "type": "Armor",
+    "row": 5160000,
+    "comment": "Rakshasa Helm"
+  },
+  {
+    "id": "fur_greaves",
+    "type": "Armor",
+    "row": 530300,
+    "comment": "Godskin Noble Trousers"
+  },
+  {
+    "id": "fur_cuirass",
+    "type": "Armor",
+    "row": 420100,
+    "comment": "Vulgar Militia Armor"
+  },
+  {
+    "id": "fur_gauntlet_left",
+    "type": "Armor",
+    "row": 540200,
+    "comment": "Depraved Perfumer Gloves"
+  },
+  {
+    "id": "fur_helm",
+    "type": "Armor",
+    "row": 1980000,
+    "comment": "Highwayman Hood"
+  },
+  {
+    "id": "imperial_greaves",
+    "type": "Armor",
+    "row": 1710300,
+    "comment": "Raya Lucarian Greaves"
+  },
+  {
+    "id": "imperial cuirass_armor",
+    "type": "Armor",
+    "row": 1761100,
+    "comment": "Gelmir Knight Armor (Altered)"
+  },
+  {
+    "id": "imperial left gauntlet",
+    "type": "Armor",
+    "row": 420200,
+    "comment": "Vulgar Militia Gauntlets"
+  },
+  {
+    "id": "imperial helmet armor",
+    "type": "Armor",
+    "row": 1730000,
+    "comment": "Radahn Soldier Helm"
+  },
+  {
+    "id": "netch_leather_greaves",
+    "type": "Armor",
+    "row": 1400300,
+    "comment": "Leather Boots"
+  },
+  {
+    "id": "netch_leather_cuirass",
+    "type": "Armor",
+    "row": 931100,
+    "comment": "Bandit Garb"
+  },
+  {
+    "id": "netch_leather_gauntlet_left",
+    "type": "Armor",
+    "row": 1400200,
+    "comment": "Leather Gloves"
+  },
+  {
+    "id": "netch_leather_helm",
+    "type": "Armor",
+    "row": 540000,
+    "comment": "Depraved Perfumer Headscarf"
+  },
+  {
+    "id": "netch_leather_boiled_cuirass",
+    "type": "Armor",
+    "row": 1400100,
+    "comment": "Leather Armor"
+  },
+  {
+    "id": "netch_leather_boiled_helm",
+    "type": "Armor",
+    "row": 420000,
+    "comment": "Vulgar Militia Helm"
+  },
+  {
+    "id": "bloodworm_helm_unique",
+    "type": "Armor",
+    "row": 5182000,
+    "comment": "Death Mask Helm"
+  },
+  {
+    "id": "bonemold_chuzei_helm",
+    "type": "Armor",
+    "row": 5253000,
+    "comment": "Divine Bird Helm"
+  },
+  {
+    "id": "bonemold_founders_helm",
+    "type": "Armor",
+    "row": 570000,
+    "comment": "Crucible Axe Helm"
+  },
+  {
+    "id": "bonedancer gauntlet",
+    "type": "Armor",
+    "row": 5080200,
+    "comment": "Dancer's Bracer"
+  },
+  {
+    "id": "boneweave gauntlet",
+    "type": "Armor",
+    "row": 5230200,
+    "comment": "Gravebird Bracelets"
+  },
+  {
+    "id": "cephalopod_helm",
+    "type": "Armor",
+    "row": 1110000,
+    "comment": "Octopus Head"
+  },
+  {
+    "id": "chest of fire",
+    "type": "Armor",
+    "row": 5180100,
+    "comment": "Fire Knight Armor"
+  },
+  {
+    "id": "chitin_mask_helm",
+    "type": "Armor",
+    "row": 5210000,
+    "comment": "Curseblade Mask"
+  },
+  {
+    "id": "chitin_watchman_helm",
+    "type": "Armor",
+    "row": 330000,
+    "comment": "Guardian Mask"
+  },
+  {
+    "id": "cloth bracer left",
+    "type": "Armor",
+    "row": 5070200,
+    "comment": "Braided Arm Wraps"
+  },
+  {
+    "id": "demon cephalopod",
+    "type": "Armor",
+    "row": 5290000,
+    "comment": "Divine Beast Head"
+  },
+  {
+    "id": "demon helm",
+    "type": "Armor",
+    "row": 5210000,
+    "comment": "Curseblade Mask"
+  },
+  {
+    "id": "demon mole crab",
+    "type": "Armor",
+    "row": 5330000,
+    "comment": "Imp Head (Lion)"
+  },
+  {
+    "id": "devil cephalopod helm",
+    "type": "Armor",
+    "row": 1090000,
+    "comment": "Silver Tear Mask"
+  },
+  {
+    "id": "devil helm",
+    "type": "Armor",
+    "row": 1890000,
+    "comment": "Omensmirk Mask"
+  },
+  {
+    "id": "devil mole crab helm",
+    "type": "Armor",
+    "row": 5320000,
+    "comment": "Greatjar"
+  },
+  {
+    "id": "dragonscale_cuirass",
+    "type": "Armor",
+    "row": 61100,
+    "comment": "Drake Knight Armor (Altered)"
+  },
+  {
+    "id": "dragonscale_helm",
+    "type": "Armor",
+    "row": 60000,
+    "comment": "Drake Knight Helm"
+  },
+  {
+    "id": "dreugh_cuirass",
+    "type": "Armor",
+    "row": 40100,
+    "comment": "Scale Armor"
+  },
+  {
+    "id": "dreugh_helm",
+    "type": "Armor",
+    "row": 970000,
+    "comment": "Omen Helm"
+  },
+  {
+    "id": "dust_adept_helm",
+    "type": "Armor",
+    "row": 5060000,
+    "comment": "High Priest Hat"
+  },
+  {
+    "id": "ebony_closed_helm_fghl",
+    "type": "Armor",
+    "row": 680000,
+    "comment": "White Mask"
+  },
+  {
+    "id": "fiend helm",
+    "type": "Armor",
+    "row": 5210000,
+    "comment": "Curseblade Mask"
+  },
+  {
+    "id": "fur_bearskin_cuirass",
+    "type": "Armor",
+    "row": 5020100,
+    "comment": "Iron Rivet Armor"
+  },
+  {
+    "id": "fur_colovian_helm",
+    "type": "Armor",
+    "row": 5020000,
+    "comment": "Pelt of Ralva"
+  },
+  {
+    "id": "gauntlet_fists_l_unique",
+    "type": "Armor",
+    "row": 5270200,
+    "comment": "Young Lion's Gauntlets"
+  },
+  {
+    "id": "gauntlet_horny_fist_l",
+    "type": "Armor",
+    "row": 5250200,
+    "comment": "Horned Warrior Gauntlets"
+  },
+  {
+    "id": "gondolier_helm",
+    "type": "Armor",
+    "row": 250000,
+    "comment": "Nomadic Merchant's Chapeau"
+  },
+  {
+    "id": "heart wall",
+    "type": "Armor",
+    "row": 5200100,
+    "comment": "Death Knight Armor"
+  },
+  {
+    "id": "helm of holy fire",
+    "type": "Armor",
+    "row": 5180000,
+    "comment": "Fire Knight Helm"
+  },
+  {
+    "id": "helm of wounding",
+    "type": "Armor",
+    "row": 210000,
+    "comment": "Briar Helm"
+  },
+  {
+    "id": "icecap_unique",
+    "type": "Armor",
+    "row": 1010000,
+    "comment": "Snow Witch Hat"
+  },
+  {
+    "id": "imperial helmet armor_Dae_curse",
+    "type": "Armor",
+    "row": 5140000,
+    "comment": "Messmer Soldier Helm"
+  },
+  {
+    "id": "imperial_chain_coif_helm",
+    "type": "Armor",
+    "row": 1100000,
+    "comment": "Chain Coif"
+  },
+  {
+    "id": "imperial_chain_cuirass",
+    "type": "Armor",
+    "row": 1100100,
+    "comment": "Chain Armor"
+  },
+  {
+    "id": "imperial_chain_greaves",
+    "type": "Armor",
+    "row": 1100300,
+    "comment": "Chain Leggings"
+  },
+  {
+    "id": "imperial_studded_cuirass",
+    "type": "Armor",
+    "row": 190100,
+    "comment": "Exile Armor"
+  },
+  {
+    "id": "indoril cuirass",
+    "type": "Armor",
+    "row": 340100,
+    "comment": "Cleanrot Armor"
+  },
+  {
+    "id": "indoril helmet",
+    "type": "Armor",
+    "row": 340000,
+    "comment": "Cleanrot Helm"
+  },
+  {
+    "id": "indoril left gauntlet",
+    "type": "Armor",
+    "row": 340200,
+    "comment": "Cleanrot Gauntlets"
+  },
+  {
+    "id": "left cloth horny fist bracer",
+    "type": "Armor",
+    "row": 5070200,
+    "comment": "Braided Arm Wraps"
+  },
+  {
+    "id": "left gauntlet of the horny fist",
+    "type": "Armor",
+    "row": 360200,
+    "comment": "Fire Prelate Gauntlets"
+  },
+  {
+    "id": "left leather bracer",
+    "type": "Armor",
+    "row": 5190200,
+    "comment": "Leather Arm Wraps"
+  },
+  {
+    "id": "left_horny_fist_gauntlet",
+    "type": "Armor",
+    "row": 5250200,
+    "comment": "Horned Warrior Gauntlets"
+  },
+  {
+    "id": "merisan helm",
+    "type": "Armor",
+    "row": 380000,
+    "comment": "Aristocrat Hat"
+  },
+  {
+    "id": "merisan_cuirass",
+    "type": "Armor",
+    "row": 380100,
+    "comment": "Aristocrat Coat"
+  },
+  {
+    "id": "mole_crab_helm",
+    "type": "Armor",
+    "row": 5320000,
+    "comment": "Greatjar"
+  },
+  {
+    "id": "morag_tong_helm",
+    "type": "Armor",
+    "row": 5280000,
+    "comment": "Shadow Militiaman Helm"
+  },
+  {
+    "id": "Mountain Spirit",
+    "type": "Armor",
+    "row": 1070100,
+    "useIcon": true,
+    "comment": "Zamor Armor"
+  },
+  {
+    "id": "newtscale_cuirass",
+    "type": "Armor",
+    "row": 670100,
+    "useIcon": true,
+    "comment": "Blue Cloth Vest"
+  },
+  {
+    "id": "nordic_iron_cuirass",
+    "type": "Armor",
+    "row": 5020100,
+    "comment": "Iron Rivet Armor"
+  },
+  {
+    "id": "nordic_iron_helm",
+    "type": "Armor",
+    "row": 5021000,
+    "comment": "Fang Helm"
+  },
+  {
+    "id": "nordic_ringmail_cuirass",
+    "type": "Armor",
+    "row": 1101100,
+    "comment": "Eye Surcoat"
+  },
+  {
+    "id": "redoran_master_helm",
+    "type": "Armor",
+    "row": 571000,
+    "comment": "Crucible Tree Helm"
+  },
+  {
+    "id": "silver_cuirass",
+    "type": "Armor",
+    "row": 5260100,
+    "comment": "Rellana's Armor"
+  },
+  {
+    "id": "silver_dukesguard_cuirass",
+    "type": "Armor",
+    "row": 5002100,
+    "comment": "Oathseeker Knight Armor"
+  },
+  {
+    "id": "silver_helm",
+    "type": "Armor",
+    "row": 5260000,
+    "comment": "Rellana's Helm"
+  },
+  {
+    "id": "slave_bracer_left",
+    "type": "Armor",
+    "row": 5210200,
+    "comment": "Ascetic's Wrist Guards"
+  },
+  {
+    "id": "storm helm",
+    "type": "Armor",
+    "row": 240000,
+    "comment": "Blue Silver Mail Hood"
+  },
+  {
+    "id": "templar bracer left",
+    "type": "Armor",
+    "row": 5150200,
+    "comment": "Black Knight Gauntlets"
+  },
+  {
+    "id": "templar_cuirass",
+    "type": "Armor",
+    "row": 5150100,
+    "comment": "Black Knight Armor"
+  },
+  {
+    "id": "templar_greaves",
+    "type": "Armor",
+    "row": 5150300,
+    "comment": "Black Knight Greaves"
+  },
+  {
+    "id": "templar_helmet_armor",
+    "type": "Armor",
+    "row": 5150000,
+    "comment": "Black Knight Helm"
+  },
+  {
+    "id": "the_chiding_cuirass",
+    "type": "Armor",
+    "row": 5070100,
+    "comment": "Braided Cord Robe"
+  },
+  {
+    "id": "trollbone_cuirass",
+    "type": "Armor",
+    "row": 301100,
+    "comment": "Shaman Furs"
+  },
+  {
+    "id": "trollbone_helm",
+    "type": "Armor",
+    "row": 301000,
+    "comment": "Shining Horned Headband"
+  },
+  {
+    "id": "velothian_helm",
+    "type": "Armor",
+    "row": 1040000,
+    "comment": "Radiant Gold Mask"
+  }
+]

--- a/JortPob/Resources/overrides/items/remap/misc.json
+++ b/JortPob/Resources/overrides/items/remap/misc.json
@@ -1,57 +1,64 @@
-{
-	"gold_001": {
-		"type": "Goods",
-		"row": 2900,
-		"text": {
-			"name": "Tiny Coin Pouch",
-			"description": "A tiny pouch of Runes.",
-			"effect": "Grants 200 Runes on use."
-		}
-	},
-	"gold_005": {
-		"type": "Goods",
-		"row": 2901,
-		"text": {
-			"name": "Small Coin Pouch",
-			"description": "A small pouch of Runes.",
-			"effect": "Grants 400 Runes on use."
-		}
-	},
-	"gold_010": {
-		"type": "Goods",
-		"row": 2902,
-		"text": {
-			"name": "Coin Pouch",
-			"description": "A pouch of Runes.",
-			"effect": "Grants 800 Runes on use."
-		}
-	},
-	"gold_025": {
-		"type": "Goods",
-		"row": 2904,
-		"text": {
-			"name": "Big Coin Pouch",
-			"description": "A big pouch of Runes.",
-			"effect": "Grants 1600 Runes on use."
-		}
-	},
-	"gold_100": {
-		"type": "Goods",
-		"row": 2910,
-		"text": {
-			"name": "Huge Coin Pouch",
-			"description": "A huge pouch of Runes.",
-			"effect": "Grants 6250 Runes on use."
-		}
-	},
-	"artifact_bittercup_01": {
-		"type": "Accessory",
-		"row": 1051,
-		"comment": "Remapping Bittercup to Radagon's Soreseal"
-	},
-	"misc_soulgem_azura": {
-		"type": "Accessory",
-		"row": 8000,
-		"comment": "Remapping Azura's Star to the Blessed Blue Dew Talisman"
-	}
-}
+[
+  {
+    "id": "gold_001",
+    "type": "Goods",
+    "row": 2900,
+    "text": {
+      "name": "Tiny Coin Pouch",
+      "description": "A tiny pouch of Runes.",
+      "effect": "Grants 200 Runes on use."
+    }
+  },
+  {
+    "id": "gold_005",
+    "type": "Goods",
+    "row": 2901,
+    "text": {
+      "name": "Small Coin Pouch",
+      "description": "A small pouch of Runes.",
+      "effect": "Grants 400 Runes on use."
+    }
+  },
+  {
+    "id": "gold_010",
+    "type": "Goods",
+    "row": 2902,
+    "text": {
+      "name": "Coin Pouch",
+      "description": "A pouch of Runes.",
+      "effect": "Grants 800 Runes on use."
+    }
+  },
+  {
+    "id": "gold_025",
+    "type": "Goods",
+    "row": 2904,
+    "text": {
+      "name": "Big Coin Pouch",
+      "description": "A big pouch of Runes.",
+      "effect": "Grants 1600 Runes on use."
+    }
+  },
+  {
+    "id": "gold_100",
+    "type": "Goods",
+    "row": 2910,
+    "text": {
+      "name": "Huge Coin Pouch",
+      "description": "A huge pouch of Runes.",
+      "effect": "Grants 6250 Runes on use."
+    }
+  },
+  {
+    "id": "artifact_bittercup_01",
+    "type": "Accessory",
+    "row": 1051,
+    "comment": "Remapping Bittercup to Radagon's Soreseal"
+  },
+  {
+    "id": "misc_soulgem_azura",
+    "type": "Accessory",
+    "row": 8000,
+    "comment": "Remapping Azura's Star to the Blessed Blue Dew Talisman"
+  }
+]

--- a/JortPob/Resources/overrides/items/remap/shields.json
+++ b/JortPob/Resources/overrides/items/remap/shields.json
@@ -1,390 +1,435 @@
-{
-    "chitin_shield": {
-        "type": "CustomWeapon",
-        "row": 30190000,
-        "infusion": "None",
-        "skill": 30000,
-        "upgrade": 3,
-        "comment": "Spiralhorn Shield | Ash: Shield Bash"
-    },
-    "chitin_towershield": {
-        "type": "CustomWeapon",
-        "row": 32090000,
-        "infusion": "None",
-        "skill": 30100,
-        "upgrade": 3,
-        "comment": "Golden Beast Crest Shield | Ash: Barricade Shield"
-    },
-    "glass_shield": {
-        "type": "CustomWeapon",
-        "row": 62510000,
-        "infusion": "Magic",
-        "skill": 30700,
-        "upgrade": 6,
-        "comment": "Carian Thrusting Shield | Ash: Golden Parry"
-    },
-    "glass_towershield": {
-        "type": "CustomWeapon",
-        "row": 62500000,
-        "infusion": "Magic",
-        "skill": 30800,
-        "upgrade": 6,
-        "comment": "Dueling Shield | Ash: Shield Crash"
-    },
-    "netch_leather_shield": {
-        "type": "CustomWeapon",
-        "row": 30020000,
-        "infusion": "None",
-        "skill": 30200,
-        "upgrade": 2,
-        "comment": "Man-serpent's Shield | Ash: Parry"
-    },
-    "netch_leather_towershield": {
-        "type": "CustomWeapon",
-        "row": 32240000,
-        "infusion": "None",
-        "skill": 30100,
-        "upgrade": 2,
-        "comment": "Eclipse Crest Greatshield | Ash: Barricade Shield"
-    },
-    "nordic_leather_shield": {
-        "type": "CustomWeapon",
-        "row": 31240000,
-        "infusion": "None",
-        "skill": 30600,
-        "upgrade": 2,
-        "comment": "Horse Crest Wooden Shield | Ash: Storm Wall"
-    },
-
-    "bonemold_shield": {
-        "type": "CustomWeapon",
-        "row": 31000000,
-        "infusion": "None",
-        "skill": 30100,
-        "upgrade": 4,
-        "comment": "Kite Shield | Ash: Barricade Shield"
-    },
-    "bonemold_towershield": {
-        "type": "CustomWeapon",
-        "row": 32090000,
-        "infusion": "None",
-        "skill": 30100,
-        "upgrade": 4,
-        "comment": "Golden Beast Crest Shield | Ash: Barricade Shield"
-    },
-    "bonemold_tshield_hlaaluguard": {
-        "type": "CustomWeapon",
-        "row": 31100000,
-        "infusion": "Quality",
-        "skill": 30000,
-        "upgrade": 3,
-        "comment": "Blue-Gold Kite Shield | Ash: Shield Bash"
-    },
-    "bonemold_tshield_hrlb": {
-        "type": "CustomWeapon",
-        "row": 31520000,
-        "infusion": "None",
-        "skill": 30100,
-        "upgrade": 4,
-        "comment": "Serpent Crest Shield | Ash: Barricade Shield"
-    },
-    "bonemold_tshield_redoranguard": {
-        "type": "CustomWeapon",
-        "row": 32200000,
-        "infusion": "Heavy",
-        "skill": 30100,
-        "upgrade": 4,
-        "comment": "Crossed-Tree Towershield | Ash: Barricade Shield"
-    },
-    "bonemold_tshield_telvanniguard": {
-        "type": "CustomWeapon",
-        "row": 62510000,
-        "infusion": "Magic",
-        "skill": 31000,
-        "upgrade": 4,
-        "comment": "Carian Thrusting Shield | Ash: Thops's Barrier"
-    },
-
-    "dragonscale_towershield": {
-        "type": "CustomWeapon",
-        "row": 62500000,
-        "infusion": "Fire",
-        "skill": 30800,
-        "upgrade": 6,
-        "comment": "Dueling Shield | Ash: Shield Crash"
-    },
-    "dreugh_shield": {
-        "type": "CustomWeapon",
-        "row": 30200000,
-        "infusion": "None",
-        "skill": 30100,
-        "upgrade": 5,
-        "comment": "Coil Shield | Ash: Barricade Shield"
-    },
-    "indoril shield": {
-        "type": "CustomWeapon",
-        "row": 31310000,
-        "infusion": "Sacred",
-        "skill": 1015,
-        "upgrade": 5,
-        "comment": "Eclipse Crest Heater Shield | Ash: Holy Ground"
-    },
-    "orcish_towershield": {
-        "type": "CustomWeapon",
-        "row": 32250000,
-        "infusion": "Heavy",
-        "skill": 30800,
-        "upgrade": 5,
-        "comment": "Cuckoo Greatshield | Ash: Shield Crash"
-    },
-
-    "daedric_shield": {
-        "type": "CustomWeapon",
-        "row": 62500000,
-        "infusion": "Occult",
-        "skill": 30800,
-        "upgrade": 10,
-        "comment": "Dueling Shield | Ash: Shield Crash"
-    },
-    "daedric_towershield": {
-        "type": "CustomWeapon",
-        "row": 62510000,
-        "infusion": "Occult",
-        "skill": 30800,
-        "upgrade": 10,
-        "comment": "Carian Thrusting Shield | Ash: Shield Crash"
-    },
-    "dwemer_shield": {
-        "type": "CustomWeapon",
-        "row": 32260000,
-        "infusion": "Lightning",
-        "skill": 30100,
-        "upgrade": 5,
-        "comment": "Golden Greatshield | Ash: Barricade Shield"
-    },
-    "ebony_shield": {
-        "type": "CustomWeapon",
-        "row": 32240000,
-        "infusion": "Heavy",
-        "skill": 30100,
-        "upgrade": 8,
-        "comment": "Eclipse Crest Greatshield | Ash: Barricade Shield"
-    },
-    "ebony_towershield": {
-        "type": "CustomWeapon",
-        "row": 32250000,
-        "infusion": "Heavy",
-        "skill": 30800,
-        "upgrade": 8,
-        "comment": "Cuckoo Greatshield | Ash: Shield Crash"
-    },
-    "imperial shield": {
-        "type": "CustomWeapon",
-        "row": 31300000,
-        "infusion": "Quality",
-        "skill": 30200,
-        "upgrade": 3,
-        "comment": "Blue Crest Heater Shield | Ash: Parry"
-    },
-    "iron_shield": {
-        "type": "CustomWeapon",
-        "row": 31000000,
-        "infusion": "Heavy",
-        "skill": 30000,
-        "upgrade": 2,
-        "comment": "Kite Shield | Ash: Shield Bash"
-    },
-    "iron_towershield": {
-        "type": "CustomWeapon",
-        "row": 32290000,
-        "infusion": "Heavy",
-        "skill": 30000,
-        "upgrade": 2,
-        "comment": "Wooden Greatshield | Ash: Shield Bash"
-    },
-    "trollbone_shield": {
-        "type": "CustomWeapon",
-        "row": 32050000,
-        "infusion": "Heavy",
-        "skill": 30600,
-        "upgrade": 4,
-        "comment": "Briar Greatshield | Ash: Storm Wall"
-    },
-    "steel_shield": {
-        "type": "CustomWeapon",
-        "row": 31300000,
-        "infusion": "Quality",
-        "skill": 30200,
-        "upgrade": 3,
-        "comment": "Blue Crest Heater Shield | Ash: Parry"
-    },
-    "steel_towershield": {
-        "type": "CustomWeapon",
-        "row": 32260000,
-        "infusion": "Quality",
-        "skill": 30000,
-        "upgrade": 3,
-        "comment": "Golden Greatshield | Ash: Shield Bash"
-    },
-    "blessed_shield": {
-        "type": "CustomWeapon",
-        "row": 31000000,
-        "infusion": "Sacred",
-        "skill": 1015,
-        "upgrade": 4,
-        "comment": "Kite Shield | Ash: Holy Ground"
-    },
-    "blessed_tower_shield": {
-        "type": "CustomWeapon",
-        "row": 32260000,
-        "infusion": "Sacred",
-        "skill": 1015,
-        "upgrade": 4,
-        "comment": "Golden Greatshield | Ash: Holy Ground"
-    },
-    "Blood_Feast_Shield": {
-        "type": "CustomWeapon",
-        "row": 32050000,
-        "useIcon": true,
-        "infusion": "Blood",
-	    "skill": 30800,
-	    "upgrade": 5,
-	    "comment": "Eclipse Crest Heater Shield | Ash: Shield Crash"
-    },
-    "darksun_shield_unique": {
-        "type": "CustomWeapon",
-        "row": 31310000,
-        "infusion": "Occult",
-        "skill": 31000,
-        "upgrade": 9,
-        "comment": "Eclipse Crest Heater Shield | Ash: Thops's Barrier"
-    },
-    "ebony_shield_auriel": {
-        "type": "CustomWeapon",
-        "row": 32260000,
-        "infusion": "Sacred",
-        "skill": 1015,
-        "upgrade": 9,
-        "comment": "Golden Greatshield | Ash: Holy Ground"
-    },
-    "feather_shield": {
-        "type": "CustomWeapon",
-        "row": 31100000,
-        "infusion": "Keen",
-        "skill": 30600,
-        "upgrade": 3,
-        "comment": "Blue-Gold Kite Shield | Ash: Storm Wall"
-    },
-    "holy_shield": {
-        "type": "CustomWeapon",
-        "row": 31310000,
-        "infusion": "Sacred",
-        "skill": 1015,
-        "upgrade": 4,
-        "comment": "Eclipse Crest Heater Shield | Ash: Holy Ground"
-    },
-    "holy_tower_shield": {
-        "type": "CustomWeapon",
-        "row": 32260000,
-        "infusion": "Sacred",
-        "skill": 1015,
-        "upgrade": 4,
-        "comment": "Golden Greatshield | Ash: Holy Ground"
-    },
-    "saint's shield": {
-        "type": "CustomWeapon",
-        "row": 32260000,
-        "infusion": "Sacred",
-        "skill": 1015,
-        "upgrade": 8,
-        "comment": "Golden Greatshield | Ash: Holy Ground"
-    },
-    "shadow_shield": {
-        "type": "CustomWeapon",
-        "row": 31310000,
-        "infusion": "Occult",
-        "skill": 30600,
-        "upgrade": 6,
-        "comment": "Eclipse Crest Heater Shield | Ash: Storm Wall"
-    },
-    "shield of the undaunted": {
-        "type": "CustomWeapon",
-        "row": 31280000,
-        "infusion": "None",
-        "skill": 30100,
-        "upgrade": 3,
-        "comment": "Beast Crest Heater Shield | Ash: Barricade Shield"
-    },
-    "shield_of_light": {
-        "type": "CustomWeapon",
-        "row": 31100000,
-        "infusion": "Sacred",
-        "skill": 30700,
-        "upgrade": 3,
-        "comment": "Blue-Gold Kite Shield | Ash: Golden Parry"
-    },
-    "shield of wounds": {
-        "type": "CustomWeapon",
-        "row": 32050000,
-        "infusion": "Blood",
-        "skill": 30800,
-        "upgrade": 5,
-        "comment": "Briar Greatshield | Ash: Shield Crash"
-    },
-    "spell_breaker_unique": {
-        "type": "CustomWeapon",
-        "row": 62510000,
-        "infusion": "Magic",
-        "skill": 31000,
-        "upgrade": 10,
-        "comment": "Carian Thrusting Shield | Ash: Thops's Barrier"
-    },
-    "spirit of indoril": {
-        "type": "CustomWeapon",
-        "row": 31310000,
-        "infusion": "Sacred",
-        "skill": 1015,
-        "upgrade": 6,
-        "comment": "Eclipse Crest Heater Shield | Ash: Holy Ground"
-    },
-    "succour of indoril": {
-        "type": "CustomWeapon",
-        "row": 31310000,
-        "infusion": "Sacred",
-        "skill": 1015,
-        "upgrade": 6,
-        "comment": "Eclipse Crest Heater Shield | Ash: Holy Ground"
-    },
-    "towershield_eleidon_unique": {
-        "type": "CustomWeapon",
-        "row": 32260000,
-        "infusion": "Sacred",
-        "skill": 1015,
-        "upgrade": 10,
-        "comment": "Golden Greatshield | Ash: Holy Ground"
-    },
-    "velothian shield": {
-        "type": "CustomWeapon",
-        "row": 31300000,
-        "infusion": "Sacred",
-        "skill": 1015,
-        "upgrade": 3,
-        "comment": "Blue Crest Heater Shield | Ash: Holy Ground"
-    },
-    "velothis_shield": {
-        "type": "CustomWeapon",
-        "row": 31100000,
-        "infusion": "Sacred",
-        "skill": 1015,
-        "upgrade": 3,
-        "comment": "Blue-Gold Kite Shield | Ash: Holy Ground"
-    },
-    "veloths_tower_shield": {
-        "type": "CustomWeapon",
-        "row": 32260000,
-        "infusion": "Sacred",
-        "skill": 1015,
-        "upgrade": 3,
-        "comment": "Golden Greatshield | Ash: Holy Ground"
-    }
-}
+[
+  {
+    "id": "chitin_shield",
+    "type": "CustomWeapon",
+    "row": 30190000,
+    "infusion": "None",
+    "skill": 30000,
+    "upgrade": 3,
+    "comment": "Spiralhorn Shield | Ash: Shield Bash"
+  },
+  {
+    "id": "chitin_towershield",
+    "type": "CustomWeapon",
+    "row": 32090000,
+    "infusion": "None",
+    "skill": 30100,
+    "upgrade": 3,
+    "comment": "Golden Beast Crest Shield | Ash: Barricade Shield"
+  },
+  {
+    "id": "glass_shield",
+    "type": "CustomWeapon",
+    "row": 62510000,
+    "infusion": "Magic",
+    "skill": 30700,
+    "upgrade": 6,
+    "comment": "Carian Thrusting Shield | Ash: Golden Parry"
+  },
+  {
+    "id": "glass_towershield",
+    "type": "CustomWeapon",
+    "row": 62500000,
+    "infusion": "Magic",
+    "skill": 30800,
+    "upgrade": 6,
+    "comment": "Dueling Shield | Ash: Shield Crash"
+  },
+  {
+    "id": "netch_leather_shield",
+    "type": "CustomWeapon",
+    "row": 30020000,
+    "infusion": "None",
+    "skill": 30200,
+    "upgrade": 2,
+    "comment": "Man-serpent's Shield | Ash: Parry"
+  },
+  {
+    "id": "netch_leather_towershield",
+    "type": "CustomWeapon",
+    "row": 32240000,
+    "infusion": "None",
+    "skill": 30100,
+    "upgrade": 2,
+    "comment": "Eclipse Crest Greatshield | Ash: Barricade Shield"
+  },
+  {
+    "id": "nordic_leather_shield",
+    "type": "CustomWeapon",
+    "row": 31240000,
+    "infusion": "None",
+    "skill": 30600,
+    "upgrade": 2,
+    "comment": "Horse Crest Wooden Shield | Ash: Storm Wall"
+  },
+  {
+    "id": "bonemold_shield",
+    "type": "CustomWeapon",
+    "row": 31000000,
+    "infusion": "None",
+    "skill": 30100,
+    "upgrade": 4,
+    "comment": "Kite Shield | Ash: Barricade Shield"
+  },
+  {
+    "id": "bonemold_towershield",
+    "type": "CustomWeapon",
+    "row": 32090000,
+    "infusion": "None",
+    "skill": 30100,
+    "upgrade": 4,
+    "comment": "Golden Beast Crest Shield | Ash: Barricade Shield"
+  },
+  {
+    "id": "bonemold_tshield_hlaaluguard",
+    "type": "CustomWeapon",
+    "row": 31100000,
+    "infusion": "Quality",
+    "skill": 30000,
+    "upgrade": 3,
+    "comment": "Blue-Gold Kite Shield | Ash: Shield Bash"
+  },
+  {
+    "id": "bonemold_tshield_hrlb",
+    "type": "CustomWeapon",
+    "row": 31520000,
+    "infusion": "None",
+    "skill": 30100,
+    "upgrade": 4,
+    "comment": "Serpent Crest Shield | Ash: Barricade Shield"
+  },
+  {
+    "id": "bonemold_tshield_redoranguard",
+    "type": "CustomWeapon",
+    "row": 32200000,
+    "infusion": "Heavy",
+    "skill": 30100,
+    "upgrade": 4,
+    "comment": "Crossed-Tree Towershield | Ash: Barricade Shield"
+  },
+  {
+    "id": "bonemold_tshield_telvanniguard",
+    "type": "CustomWeapon",
+    "row": 62510000,
+    "infusion": "Magic",
+    "skill": 31000,
+    "upgrade": 4,
+    "comment": "Carian Thrusting Shield | Ash: Thops's Barrier"
+  },
+  {
+    "id": "dragonscale_towershield",
+    "type": "CustomWeapon",
+    "row": 62500000,
+    "infusion": "Fire",
+    "skill": 30800,
+    "upgrade": 6,
+    "comment": "Dueling Shield | Ash: Shield Crash"
+  },
+  {
+    "id": "dreugh_shield",
+    "type": "CustomWeapon",
+    "row": 30200000,
+    "infusion": "None",
+    "skill": 30100,
+    "upgrade": 5,
+    "comment": "Coil Shield | Ash: Barricade Shield"
+  },
+  {
+    "id": "indoril shield",
+    "type": "CustomWeapon",
+    "row": 31310000,
+    "infusion": "Sacred",
+    "skill": 1015,
+    "upgrade": 5,
+    "comment": "Eclipse Crest Heater Shield | Ash: Holy Ground"
+  },
+  {
+    "id": "orcish_towershield",
+    "type": "CustomWeapon",
+    "row": 32250000,
+    "infusion": "Heavy",
+    "skill": 30800,
+    "upgrade": 5,
+    "comment": "Cuckoo Greatshield | Ash: Shield Crash"
+  },
+  {
+    "id": "daedric_shield",
+    "type": "CustomWeapon",
+    "row": 62500000,
+    "infusion": "Occult",
+    "skill": 30800,
+    "upgrade": 10,
+    "comment": "Dueling Shield | Ash: Shield Crash"
+  },
+  {
+    "id": "daedric_towershield",
+    "type": "CustomWeapon",
+    "row": 62510000,
+    "infusion": "Occult",
+    "skill": 30800,
+    "upgrade": 10,
+    "comment": "Carian Thrusting Shield | Ash: Shield Crash"
+  },
+  {
+    "id": "dwemer_shield",
+    "type": "CustomWeapon",
+    "row": 32260000,
+    "infusion": "Lightning",
+    "skill": 30100,
+    "upgrade": 5,
+    "comment": "Golden Greatshield | Ash: Barricade Shield"
+  },
+  {
+    "id": "ebony_shield",
+    "type": "CustomWeapon",
+    "row": 32240000,
+    "infusion": "Heavy",
+    "skill": 30100,
+    "upgrade": 8,
+    "comment": "Eclipse Crest Greatshield | Ash: Barricade Shield"
+  },
+  {
+    "id": "ebony_towershield",
+    "type": "CustomWeapon",
+    "row": 32250000,
+    "infusion": "Heavy",
+    "skill": 30800,
+    "upgrade": 8,
+    "comment": "Cuckoo Greatshield | Ash: Shield Crash"
+  },
+  {
+    "id": "imperial shield",
+    "type": "CustomWeapon",
+    "row": 31300000,
+    "infusion": "Quality",
+    "skill": 30200,
+    "upgrade": 3,
+    "comment": "Blue Crest Heater Shield | Ash: Parry"
+  },
+  {
+    "id": "iron_shield",
+    "type": "CustomWeapon",
+    "row": 31000000,
+    "infusion": "Heavy",
+    "skill": 30000,
+    "upgrade": 2,
+    "comment": "Kite Shield | Ash: Shield Bash"
+  },
+  {
+    "id": "iron_towershield",
+    "type": "CustomWeapon",
+    "row": 32290000,
+    "infusion": "Heavy",
+    "skill": 30000,
+    "upgrade": 2,
+    "comment": "Wooden Greatshield | Ash: Shield Bash"
+  },
+  {
+    "id": "trollbone_shield",
+    "type": "CustomWeapon",
+    "row": 32050000,
+    "infusion": "Heavy",
+    "skill": 30600,
+    "upgrade": 4,
+    "comment": "Briar Greatshield | Ash: Storm Wall"
+  },
+  {
+    "id": "steel_shield",
+    "type": "CustomWeapon",
+    "row": 31300000,
+    "infusion": "Quality",
+    "skill": 30200,
+    "upgrade": 3,
+    "comment": "Blue Crest Heater Shield | Ash: Parry"
+  },
+  {
+    "id": "steel_towershield",
+    "type": "CustomWeapon",
+    "row": 32260000,
+    "infusion": "Quality",
+    "skill": 30000,
+    "upgrade": 3,
+    "comment": "Golden Greatshield | Ash: Shield Bash"
+  },
+  {
+    "id": "blessed_shield",
+    "type": "CustomWeapon",
+    "row": 31000000,
+    "infusion": "Sacred",
+    "skill": 1015,
+    "upgrade": 4,
+    "comment": "Kite Shield | Ash: Holy Ground"
+  },
+  {
+    "id": "blessed_tower_shield",
+    "type": "CustomWeapon",
+    "row": 32260000,
+    "infusion": "Sacred",
+    "skill": 1015,
+    "upgrade": 4,
+    "comment": "Golden Greatshield | Ash: Holy Ground"
+  },
+  {
+    "id": "Blood_Feast_Shield",
+    "type": "CustomWeapon",
+    "row": 32050000,
+    "useIcon": true,
+    "infusion": "Blood",
+    "skill": 30800,
+    "upgrade": 5,
+    "comment": "Eclipse Crest Heater Shield | Ash: Shield Crash"
+  },
+  {
+    "id": "darksun_shield_unique",
+    "type": "CustomWeapon",
+    "row": 31310000,
+    "infusion": "Occult",
+    "skill": 31000,
+    "upgrade": 9,
+    "comment": "Eclipse Crest Heater Shield | Ash: Thops's Barrier"
+  },
+  {
+    "id": "ebony_shield_auriel",
+    "type": "CustomWeapon",
+    "row": 32260000,
+    "infusion": "Sacred",
+    "skill": 1015,
+    "upgrade": 9,
+    "comment": "Golden Greatshield | Ash: Holy Ground"
+  },
+  {
+    "id": "feather_shield",
+    "type": "CustomWeapon",
+    "row": 31100000,
+    "infusion": "Keen",
+    "skill": 30600,
+    "upgrade": 3,
+    "comment": "Blue-Gold Kite Shield | Ash: Storm Wall"
+  },
+  {
+    "id": "holy_shield",
+    "type": "CustomWeapon",
+    "row": 31310000,
+    "infusion": "Sacred",
+    "skill": 1015,
+    "upgrade": 4,
+    "comment": "Eclipse Crest Heater Shield | Ash: Holy Ground"
+  },
+  {
+    "id": "holy_tower_shield",
+    "type": "CustomWeapon",
+    "row": 32260000,
+    "infusion": "Sacred",
+    "skill": 1015,
+    "upgrade": 4,
+    "comment": "Golden Greatshield | Ash: Holy Ground"
+  },
+  {
+    "id": "saint's shield",
+    "type": "CustomWeapon",
+    "row": 32260000,
+    "infusion": "Sacred",
+    "skill": 1015,
+    "upgrade": 8,
+    "comment": "Golden Greatshield | Ash: Holy Ground"
+  },
+  {
+    "id": "shadow_shield",
+    "type": "CustomWeapon",
+    "row": 31310000,
+    "infusion": "Occult",
+    "skill": 30600,
+    "upgrade": 6,
+    "comment": "Eclipse Crest Heater Shield | Ash: Storm Wall"
+  },
+  {
+    "id": "shield of the undaunted",
+    "type": "CustomWeapon",
+    "row": 31280000,
+    "infusion": "None",
+    "skill": 30100,
+    "upgrade": 3,
+    "comment": "Beast Crest Heater Shield | Ash: Barricade Shield"
+  },
+  {
+    "id": "shield_of_light",
+    "type": "CustomWeapon",
+    "row": 31100000,
+    "infusion": "Sacred",
+    "skill": 30700,
+    "upgrade": 3,
+    "comment": "Blue-Gold Kite Shield | Ash: Golden Parry"
+  },
+  {
+    "id": "shield of wounds",
+    "type": "CustomWeapon",
+    "row": 32050000,
+    "infusion": "Blood",
+    "skill": 30800,
+    "upgrade": 5,
+    "comment": "Briar Greatshield | Ash: Shield Crash"
+  },
+  {
+    "id": "spell_breaker_unique",
+    "type": "CustomWeapon",
+    "row": 62510000,
+    "infusion": "Magic",
+    "skill": 31000,
+    "upgrade": 10,
+    "comment": "Carian Thrusting Shield | Ash: Thops's Barrier"
+  },
+  {
+    "id": "spirit of indoril",
+    "type": "CustomWeapon",
+    "row": 31310000,
+    "infusion": "Sacred",
+    "skill": 1015,
+    "upgrade": 6,
+    "comment": "Eclipse Crest Heater Shield | Ash: Holy Ground"
+  },
+  {
+    "id": "succour of indoril",
+    "type": "CustomWeapon",
+    "row": 31310000,
+    "infusion": "Sacred",
+    "skill": 1015,
+    "upgrade": 6,
+    "comment": "Eclipse Crest Heater Shield | Ash: Holy Ground"
+  },
+  {
+    "id": "towershield_eleidon_unique",
+    "type": "CustomWeapon",
+    "row": 32260000,
+    "infusion": "Sacred",
+    "skill": 1015,
+    "upgrade": 10,
+    "comment": "Golden Greatshield | Ash: Holy Ground"
+  },
+  {
+    "id": "velothian shield",
+    "type": "CustomWeapon",
+    "row": 31300000,
+    "infusion": "Sacred",
+    "skill": 1015,
+    "upgrade": 3,
+    "comment": "Blue Crest Heater Shield | Ash: Holy Ground"
+  },
+  {
+    "id": "velothis_shield",
+    "type": "CustomWeapon",
+    "row": 31100000,
+    "infusion": "Sacred",
+    "skill": 1015,
+    "upgrade": 3,
+    "comment": "Blue-Gold Kite Shield | Ash: Holy Ground"
+  },
+  {
+    "id": "veloths_tower_shield",
+    "type": "CustomWeapon",
+    "row": 32260000,
+    "infusion": "Sacred",
+    "skill": 1015,
+    "upgrade": 3,
+    "comment": "Golden Greatshield | Ash: Holy Ground"
+  }
+]

--- a/JortPob/Resources/overrides/items/remap/weapons.json
+++ b/JortPob/Resources/overrides/items/remap/weapons.json
@@ -1,5 +1,6 @@
-{
-  "iron shardaxe": {
+[
+  {
+    "id": "iron shardaxe",
     "type": "CustomWeapon",
     "row": 14000000,
     "infusion": "Cold",
@@ -7,22 +8,26 @@
     "upgrade": 1,
     "comment": "Remapping the iron shardaxe to a battle axe with +1 cold infusion and the hoarfrost stomp skill."
   },
-  "iron longsword": {
+  {
+    "id": "iron longsword",
     "type": "Weapon",
     "row": 2000000,
     "comment": "Remapping 'iron longsword' to the Elden Ring Longsword."
   },
-  "miner's pick": {
+  {
+    "id": "miner's pick",
     "type": "Weapon",
     "row": 12140000,
     "comment": "Pickaxe"
   },
-  "long bow": {
+  {
+    "id": "long bow",
     "type": "Weapon",
     "row": 41000000,
     "comment": "Longbow"
   },
-  "steel flameslayer": {
+  {
+    "id": "steel flameslayer",
     "type": "CustomWeapon",
     "row": 3050000,
     "infusion": "FlameArt",
@@ -30,7 +35,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel flameslayer to a flamberge with +3 fire infusion and the flaming slash skill."
   },
-  "steel flamesword": {
+  {
+    "id": "steel flamesword",
     "type": "CustomWeapon",
     "row": 7140000,
     "infusion": "FlameArt",
@@ -38,7 +44,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel flamesword to a scimitar with +3 fire infusion and the flaming slash skill."
   },
-  "steel frostsword": {
+  {
+    "id": "steel frostsword",
     "type": "CustomWeapon",
     "row": 7140000,
     "infusion": "Cold",
@@ -46,37 +53,43 @@
     "upgrade": 3,
     "comment": "Remapping the steel frostsword to a scimitar with +3 cold infusion and the chilling mist skill."
   },
-  "steel halberd": {
+  {
+    "id": "steel halberd",
     "type": "CustomWeapon",
     "row": 18000000,
     "upgrade": 2,
     "comment": "Remapping the steel halberd to a halberd +2"
   },
-  "steel katana": {
+  {
+    "id": "steel katana",
     "type": "CustomWeapon",
     "row": 9000000,
     "upgrade": 2,
     "comment": "Remapping Steel Katana to Uchigatana +2"
   },
-  "steel longbow": {
+  {
+    "id": "steel longbow",
     "type": "CustomWeapon",
     "row": 41010000,
     "upgrade": 2,
     "comment": "Remapping Steel Longbow to Albinauric Bow +2"
   },
-  "steel longsword": {
+  {
+    "id": "steel longsword",
     "type": "CustomWeapon",
     "row": 2000000,
     "upgrade": 2,
     "comment": "Remapping Steel Longsword to Longsword +2"
   },
-  "steel mace": {
+  {
+    "id": "steel mace",
     "type": "CustomWeapon",
     "row": 11000000,
     "upgrade": 2,
     "comment": "Remapping Steel Mace to Mace +2"
   },
-  "steel poisonsword": {
+  {
+    "id": "steel poisonsword",
     "type": "CustomWeapon",
     "row": 2010000,
     "infusion": "Poison",
@@ -84,13 +97,15 @@
     "upgrade": 3,
     "comment": "Remapping the steel poisonsword to a longsword with +3 poison infusion and poison mist skill."
   },
-  "steel saber": {
+  {
+    "id": "steel saber",
     "type": "CustomWeapon",
     "row": 5000000,
     "upgrade": 2,
     "comment": "Remapping Steel Saber to Estoc +2"
   },
-  "steel shardaxe": {
+  {
+    "id": "steel shardaxe",
     "type": "CustomWeapon",
     "row": 14000000,
     "infusion": "Cold",
@@ -98,7 +113,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel shardaxe to a battle axe with +3 cold infusion and the hoarfrost stomp skill."
   },
-  "steel shardblade": {
+  {
+    "id": "steel shardblade",
     "type": "CustomWeapon",
     "row": 2010000,
     "infusion": "Cold",
@@ -106,7 +122,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel shardblade to a short sword with +3 cold infusion and the chilling mist skill."
   },
-  "steel shardcleaver": {
+  {
+    "id": "steel shardcleaver",
     "type": "CustomWeapon",
     "row": 18000000,
     "infusion": "Cold",
@@ -114,7 +131,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel shardcleaver to a +3 cold halberd with the hoarfrost stomp skill."
   },
-  "steel shardmace": {
+  {
+    "id": "steel shardmace",
     "type": "CustomWeapon",
     "row": 11000000,
     "infusion": "Cold",
@@ -122,7 +140,8 @@
     "upgrade": 3,
     "comment": "Remapping Steel Shardmace to Cold Mace +2 with Hoarfrost Stomp"
   },
-  "steel shardmauler": {
+  {
+    "id": "steel shardmauler",
     "type": "CustomWeapon",
     "row": 11080000,
     "infusion": "Cold",
@@ -130,7 +149,8 @@
     "upgrade": 3,
     "comment": "Remapping Steel Shardmauler to Cold Hammer +3 with Divine Beast Frost Stomp"
   },
-  "steel shardscythe": {
+  {
+    "id": "steel shardscythe",
     "type": "CustomWeapon",
     "row": 9000000,
     "infusion": "Cold",
@@ -138,7 +158,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel shardscythe to a +3 cold uchigatana with the chilling mist skill."
   },
-  "steel shardskewer": {
+  {
+    "id": "steel shardskewer",
     "type": "CustomWeapon",
     "row": 16070000,
     "infusion": "Cold",
@@ -146,7 +167,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel shardskewer to a +3 cold pike with the ice spear skill."
   },
-  "steel shardslayer": {
+  {
+    "id": "steel shardslayer",
     "type": "CustomWeapon",
     "row": 3050000,
     "infusion": "Cold",
@@ -154,7 +176,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel shardskewer to a +3 cold flamberge with the hoarfrost stomp skill."
   },
-  "steel shardsword": {
+  {
+    "id": "steel shardsword",
     "type": "CustomWeapon",
     "row": 2000000,
     "infusion": "Cold",
@@ -162,13 +185,15 @@
     "upgrade": 3,
     "comment": "Remapping the steel shardsword to a +3 cold longsword with the chilling mist skill."
   },
-  "steel shortsword": {
+  {
+    "id": "steel shortsword",
     "type": "CustomWeapon",
     "row": 2010000,
     "upgrade": 2,
     "comment": "Remapping Steel Shortsword to Short Sword +2"
   },
-  "steel sparkaxe": {
+  {
+    "id": "steel sparkaxe",
     "type": "CustomWeapon",
     "row": 14000000,
     "infusion": "Lightning",
@@ -176,7 +201,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel sparkaxe to a battle axe with +3 lightning infusion and the lightning slash skill."
   },
-  "steel sparkblade": {
+  {
+    "id": "steel sparkblade",
     "type": "CustomWeapon",
     "row": 2010000,
     "infusion": "Lightning",
@@ -184,7 +210,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel sparkblade to a short sword with +3 lightning infusion and the lightning slash skill."
   },
-  "steel sparkcleaver": {
+  {
+    "id": "steel sparkcleaver",
     "type": "CustomWeapon",
     "row": 18000000,
     "infusion": "Lightning",
@@ -192,7 +219,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel shardcleaver to a +3 lightning halberd with the lightning slash skill."
   },
-  "steel sparkmace": {
+  {
+    "id": "steel sparkmace",
     "type": "CustomWeapon",
     "row": 11000000,
     "infusion": "Lightning",
@@ -200,7 +228,8 @@
     "upgrade": 3,
     "comment": "Remapping Steel Sparkmace to Lightning Mace +3 with Lightning Ram"
   },
-  "steel sparkmauler": {
+  {
+    "id": "steel sparkmauler",
     "type": "CustomWeapon",
     "row": 11080000,
     "infusion": "Lightning",
@@ -208,7 +237,8 @@
     "upgrade": 3,
     "comment": "Remapping Steel Sparkmauler to Lightning Hammer +3 with Lightning Ram"
   },
-  "steel sparkscythe": {
+  {
+    "id": "steel sparkscythe",
     "type": "CustomWeapon",
     "row": 9000000,
     "infusion": "Lightning",
@@ -216,7 +246,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel sparkscythe to a +3 Lightning uchigatana with the blinkbolt skill."
   },
-  "steel sparkskewer": {
+  {
+    "id": "steel sparkskewer",
     "type": "CustomWeapon",
     "row": 16070000,
     "infusion": "Lightning",
@@ -224,7 +255,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel sparkskewer to a +3 lightning pike with the thunderbolt skill."
   },
-  "steel sparkslayer": {
+  {
+    "id": "steel sparkslayer",
     "type": "CustomWeapon",
     "row": 3050000,
     "infusion": "Lightning",
@@ -232,7 +264,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel sparkslayer to a +3 Lightning flamberge with the lightning slash skill."
   },
-  "steel sparksword": {
+  {
+    "id": "steel sparksword",
     "type": "CustomWeapon",
     "row": 2000000,
     "infusion": "Lightning",
@@ -240,20 +273,23 @@
     "upgrade": 3,
     "comment": "Remapping the steel sparksword to a +3 lightning longsword with the lightning slash skill."
   },
-  "steel spear": {
+  {
+    "id": "steel spear",
     "type": "CustomWeapon",
     "row": 16070000,
     "upgrade": 2,
     "comment": "Remapping the steel halberd to a pike +2"
   },
-  "steel spear of impaling thrust": {
+  {
+    "id": "steel spear of impaling thrust",
     "type": "CustomWeapon",
     "row": 16030000,
     "skill": 11600,
     "upgrade": 6,
     "comment": "Remapping the steel spear of impaling thrusts to a +6 pike and giant hurl skill."
   },
-  "steel spider blade": {
+  {
+    "id": "steel spider blade",
     "type": "CustomWeapon",
     "row": 7080000,
     "skill": 22400,
@@ -261,13 +297,15 @@
     "upgrade": 4,
     "comment": "Remapping the steel spear of impaling thrusts to a +4 blood scavenger's curved sword and blood blade skill."
   },
-  "steel staff": {
+  {
+    "id": "steel staff",
     "type": "CustomWeapon",
     "row": 33060000,
     "upgrade": 2,
     "comment": "Remapping Steel Staff to Demi Human Queen's Staff +2"
   },
-  "steel viperaxe": {
+  {
+    "id": "steel viperaxe",
     "type": "CustomWeapon",
     "row": 14000000,
     "infusion": "Poison",
@@ -275,7 +313,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel viperaxe to a battle axe with +3 poison infusion and the poison mist skill."
   },
-  "steel viperblade": {
+  {
+    "id": "steel viperblade",
     "type": "CustomWeapon",
     "row": 2010000,
     "infusion": "Poison",
@@ -283,7 +322,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel viperblade to a short sword with +3 poison infusion and the poison moth flight skill."
   },
-  "steel vipercleaver": {
+  {
+    "id": "steel vipercleaver",
     "type": "CustomWeapon",
     "row": 18000000,
     "infusion": "Poison",
@@ -291,7 +331,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel vipercleaver to a +3 Poison halberd with the poison mist skill."
   },
-  "steel vipermace": {
+  {
+    "id": "steel vipermace",
     "type": "CustomWeapon",
     "row": 11000000,
     "infusion": "Poison",
@@ -299,7 +340,8 @@
     "upgrade": 3,
     "comment": "Remapping Steel Vipermace to Poison Mace +3 with Poison Mist"
   },
-  "steel vipermauler": {
+  {
+    "id": "steel vipermauler",
     "type": "CustomWeapon",
     "row": 11080000,
     "infusion": "Poison",
@@ -307,7 +349,8 @@
     "upgrade": 3,
     "comment": "Remapping Steel Vipermauler to Poison Hammer +3 with Poison Mist"
   },
-  "steel viperscythe": {
+  {
+    "id": "steel viperscythe",
     "type": "CustomWeapon",
     "row": 9000000,
     "infusion": "Poison",
@@ -315,7 +358,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel Viperscythe to a +3 Poison uchigatana with the poison moth flight skill."
   },
-  "steel viperskewer": {
+  {
+    "id": "steel viperskewer",
     "type": "CustomWeapon",
     "row": 16070000,
     "infusion": "Poison",
@@ -323,7 +367,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel viperskewer to a +3 poison pike with the poison mist skill."
   },
-  "steel viperslayer": {
+  {
+    "id": "steel viperslayer",
     "type": "CustomWeapon",
     "row": 3050000,
     "infusion": "Poison",
@@ -331,7 +376,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel viperslayer to a +3 Poison flamberge with the poison mist skill."
   },
-  "steel vipersword": {
+  {
+    "id": "steel vipersword",
     "type": "CustomWeapon",
     "row": 2000000,
     "infusion": "Poison",
@@ -339,7 +385,8 @@
     "upgrade": 3,
     "comment": "Remapping the steel vipersword to a +3 poison longsword with the poison moth flight skill."
   },
-  "steel stormsword": {
+  {
+    "id": "steel stormsword",
     "type": "CustomWeapon",
     "row": 2240000,
     "infusion": "Lightning",
@@ -347,13 +394,15 @@
     "upgrade": 3,
     "comment": "Remapping the steel sparksword to a +3 lightning Warhawk's Talon with the lightning slash skill."
   },
-  "steel tanto": {
+  {
+    "id": "steel tanto",
     "type": "CustomWeapon",
     "row": 1150000,
     "upgrade": 2,
     "comment": "Remapping Steel Tanto to Erdsteel Dagger +2"
   },
-  "steel throwing knife": {
+  {
+    "id": "steel throwing knife",
     "type": "Goods",
     "row": 1730,
     "text": {
@@ -362,7 +411,8 @@
       "effect": "Deals Damage"
     }
   },
-  "steel throwing star": {
+  {
+    "id": "steel throwing star",
     "type": "Goods",
     "row": 1730,
     "text": {
@@ -371,19 +421,22 @@
       "effect": "Deals Damage"
     }
   },
-  "steel wakizashi": {
+  {
+    "id": "steel wakizashi",
     "type": "CustomWeapon",
     "row": 1100000,
     "upgrade": 2,
     "comment": "Remapping Steel Wakizashi to Wakizashi +2"
   },
-  "steel war axe": {
+  {
+    "id": "steel war axe",
     "type": "CustomWeapon",
     "row": 14000000,
     "upgrade": 2,
     "comment": "Remapping Steel War Axe to Battle Axe +2"
   },
-  "steel war axe of deep biting": {
+  {
+    "id": "steel war axe of deep biting",
     "type": "CustomWeapon",
     "row": 14000000,
     "infusion": "Heavy",
@@ -391,13 +444,15 @@
     "upgrade": 6,
     "comment": "Remapping Steel War Axe of Deep Biting to Battle Axe +6 with Stamp (Sweep) skill."
   },
-  "steel warhammer": {
+  {
+    "id": "steel warhammer",
     "type": "CustomWeapon",
     "row": 11080000,
     "upgrade": 2,
     "comment": "Remapping Steel Warhammer to hammer +2"
   },
-  "steel warhammer of smiting": {
+  {
+    "id": "steel warhammer of smiting",
     "type": "CustomWeapon",
     "row": 11080000,
     "infusion": "Heavy",
@@ -405,7 +460,8 @@
     "upgrade": 6,
     "comment": "Remapping Steel Warhammer of Smiting to hammer +6 with Lion's Claw skill."
   },
-  "stormblade": {
+  {
+    "id": "stormblade",
     "type": "CustomWeapon",
     "row": 7060000,
     "infusion": "Lightning",
@@ -413,17 +469,20 @@
     "upgrade": 4,
     "comment": "Remapping the stormblade to a Flowing Curved Sword with +4 lightning infusion and the thunderbolt skill."
   },
-  "viper arrow": {
+  {
+    "id": "viper arrow",
     "type": "Weapon",
     "row": 50160000,
     "comment": "Remapping Viper Arrow to Poisonbone Arrow"
   },
-  "viper_bolt": {
+  {
+    "id": "viper_bolt",
     "type": "Weapon",
     "row": 52140000,
     "comment": "Remapping Viper Bolt to Poisonbone Bolt"
   },
-  "viperstar": {
+  {
+    "id": "viperstar",
     "type": "Goods",
     "row": 1720,
     "text": {
@@ -432,32 +491,37 @@
       "effect": "Inflicts Poison Buildup"
     }
   },
-  "war_axe_airan_ammu": {
+  {
+    "id": "war_axe_airan_ammu",
     "type": "CustomWeapon",
     "row": 15040000,
     "upgrade": 8,
     "comment": "Remapping War Axe of Airan Ammu to Axe of Godrick +8"
   },
-  "water spear": {
+  {
+    "id": "water spear",
     "type": "CustomWeapon",
     "row": 16020000,
     "skill": 20300,
     "comment": "Remapping the water spear to a crystal spear +4 and the glintstone pebble skill."
   },
-  "we_hellfirestaff": {
+  {
+    "id": "we_hellfirestaff",
     "type": "CustomWeapon",
     "row": 33050000,
     "upgrade": 8,
     "skill": 12000,
     "comment": "Remapping Hellfire Staff to Gelmir Glintstone Staff +8 with Spinning Weapon Skill"
   },
-  "we_illkurok": {
+  {
+    "id": "we_illkurok",
     "type": "CustomWeapon",
     "row": 16090000,
     "upgrade": 8,
     "comment": "Remapping Illkurok to Bolt of Gransax +8"
   },
-  "we_shimsil": {
+  {
+    "id": "we_shimsil",
     "type": "CustomWeapon",
     "row": 1030000,
     "infusion": "Occult",
@@ -465,13 +529,15 @@
     "skill": 60200,
     "comment": "Remapping Shimsil to Misericorde +8 Occult Infusion with Assassin's Gambit skill"
   },
-  "we_stormforge": {
+  {
+    "id": "we_stormforge",
     "type": "CustomWeapon",
     "row": 18140000,
     "upgrade": 8,
     "comment": "Remapping Stormforge to Dragon Halberd +8"
   },
-  "widowmaker_unique": {
+  {
+    "id": "widowmaker_unique",
     "type": "CustomWeapon",
     "row": 15120000,
     "infusion": "Heavy",
@@ -479,13 +545,15 @@
     "upgrade": 8,
     "comment": "Remapping the widowmaker to a +8 Butchering Knife with the Braggart's Roar skill."
   },
-  "wild flamesword": {
+  {
+    "id": "wild flamesword",
     "type": "CustomWeapon",
     "row": 7050000,
     "upgrade": 6,
     "comment": "Remapping the wild flamesword to a magma blade +6"
   },
-  "wild flameblade": {
+  {
+    "id": "wild flameblade",
     "type": "CustomWeapon",
     "row": 1150000,
     "infusion": "FlameArt",
@@ -493,7 +561,8 @@
     "upgrade": 6,
     "comment": "Remapping the wild flameblade to a erdsteel dagger with +6 flameart infusion with the flame spear skill"
   },
-  "wild shardblade": {
+  {
+    "id": "wild shardblade",
     "type": "CustomWeapon",
     "row": 1090000,
     "infusion": "Cold",
@@ -501,7 +570,8 @@
     "upgrade": 6,
     "comment": "Remapping the wild shardblade to a great knife with +6 cold infusion and the ghostflame call skill."
   },
-  "wild shardsword": {
+  {
+    "id": "wild shardsword",
     "type": "CustomWeapon",
     "row": 2210000,
     "infusion": "Cold",
@@ -509,7 +579,8 @@
     "upgrade": 6,
     "comment": "Remapping the wild shardsword to a cane sword with +6 cold infusion and the ghostflame call skill."
   },
-  "wild sparkblade": {
+  {
+    "id": "wild sparkblade",
     "type": "CustomWeapon",
     "row": 1100000,
     "infusion": "Lightning",
@@ -517,7 +588,8 @@
     "upgrade": 6,
     "comment": "Remapping the wild sparkblade to a Wakizashi with +6 lightning infusion and the blinkbolt skill."
   },
-  "wild sparksword": {
+  {
+    "id": "wild sparksword",
     "type": "CustomWeapon",
     "row": 2230000,
     "infusion": "Lightning",
@@ -525,7 +597,8 @@
     "upgrade": 6,
     "comment": "Remapping the wild sparksword to a noble's slender sword with +6 lightning infusion and the blinkbolt skill."
   },
-  "wild viperblade": {
+  {
+    "id": "wild viperblade",
     "type": "CustomWeapon",
     "row": 1060000,
     "infusion": "Poison",
@@ -533,7 +606,8 @@
     "upgrade": 6,
     "comment": "Remapping the wild viperblade to a celebrant's sickle with +6 poison infusion and the poison moth flight skill."
   },
-  "wild vipersword": {
+  {
+    "id": "wild vipersword",
     "type": "CustomWeapon",
     "row": 5020000,
     "infusion": "Poison",
@@ -541,7 +615,8 @@
     "upgrade": 6,
     "comment": "Remapping the wild vipersword to a rapier with +6 poison infusion and the poison moth flight skill."
   },
-  "Wind of Ahaz": {
+  {
+    "id": "Wind of Ahaz",
     "type": "CustomWeapon",
     "row": 1061200,
     "infusion": "Occult",
@@ -549,17 +624,19 @@
     "upgrade": 2,
     "comment": "Remapping Wind of Ahaz to a +2 Occult Celebrant's Sickle with the assassin's gambit skill."
   },
-  "wooden staff": {
+  {
+    "id": "wooden staff",
     "type": "Weapon",
     "row": 33200000,
     "comment": "Remapping Wooden Staff as Academy Glintstone Staff"
   },
-  "glass netch dagger": {
+  {
+    "id": "glass netch dagger",
     "type": "CustomWeapon",
     "row": 1000000,
     "infusion": "Blood",
-    "skill" : 10800,
+    "skill": 10800,
     "upgrade": 8,
     "comment": "Remapping the glass netch dagger to a dagger with +8 blood infusion and the blood tax skill."
   }
-}
+]

--- a/JortPob/Test.cs
+++ b/JortPob/Test.cs
@@ -100,7 +100,7 @@ namespace JortPob
             Bind.BindMaterials(Path.Combine(Const.OUTPUT_PATH, "material", "allmaterial.matbinbnd.dcx"));
 
             // all our terrain map pieces are now in the super overworld so this is easier lol
-            string map = "60";
+            //string map = "60";
             string name = "60_00_00_99";
             foreach (Tuple<TerrainInfo, int> values in OUTPUT)
             {

--- a/JortPob/TextManager.cs
+++ b/JortPob/TextManager.cs
@@ -16,7 +16,7 @@ namespace JortPob
 
         private Dictionary<TextType, FMG> menu, item;
 
-        private volatile int nextTopicId, nextNpcNameId, nextActionButtonId, nextLocationId, nextMenuId, nextTutorial, nextMapEventText, nextWeaponEffectId, nextLoadScreenTipId;
+        private volatile int nextTopicId, nextNpcNameId, nextActionButtonId, nextLocationId, nextMenuId, nextTutorial, nextMapEventText, nextWeaponEffectId/*, nextLoadScreenTipId*/;
 
         public TextManager()
         {
@@ -28,7 +28,7 @@ namespace JortPob
             nextTutorial = 500000;
             nextMapEventText = 20209000;
             nextWeaponEffectId = 7000;
-            nextLoadScreenTipId = 300;
+            //nextLoadScreenTipId = 300;
 
             Dictionary<TextType, FMG> LoadMsgBnd(string path)
             {

--- a/JortPob/Worker/CellWorker.cs
+++ b/JortPob/Worker/CellWorker.cs
@@ -54,7 +54,7 @@ namespace JortPob.Worker
             var cells = cellRecords.AsParallel()
                 .WithDegreeOfParallelism(Const.THREAD_COUNT)
                 .Select(node => {
-                        Cell cell = MakeCell(node, esm);
+                        Cell cell = MakeCell(node, esm)!;
                         Lort.TaskIterate(); // Progress bar update
                         return cell;
                     })

--- a/JortUX/JortUX.csproj
+++ b/JortUX/JortUX.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Cleaned up all the warnings. Some of the annoying ones are the nullable types which are informative but do cause warnings in #nullable false setups. I want devs to notice warnings when they pop up and not be drowned in existing ones.

Added x64 build configuration since some of the dlls were built for x64 and, while compatible with x32, it may be a good idea to fully build for x64 since we use so much memory anyways.

The json stuff obviously changes how we do things a bit. I could revert some of it, but having an id parameter instead of named map entries makes the structure more consistent.